### PR TITLE
COM-1390 add eslint for hooks + fix the use of a state

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,8 @@ module.exports = {
   },
   extends: [
     'eslint:recommended',
-    'plugin:react/recommended'
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended'
   ],
   parserOptions: {
     ecmaFeatures: {
@@ -22,6 +23,8 @@ module.exports = {
     semi: ['error', 'always'],
     'react/display-name': 'off',
     'max-len': ['error', { 'code' : 120, 'tabWidth': 2 }],
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn'
   },
   globals: {
     __DEV__: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4975,6 +4975,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.8.tgz",
+      "integrity": "sha512-6SSb5AiMCPd8FDJrzah+Z4F44P2CdOaK026cXFV+o/xSRzfOiV1FNFeLl2z6xm3yqWOQEZ5OfVgiec90qV2xrQ==",
+      "dev": true
+    },
     "eslint-plugin-relay": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-relay/-/eslint-plugin-relay-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     ]
   },
   "dependencies": {
+    "@react-native-community/async-storage": "~1.11.0",
     "@react-native-community/masked-view": "0.1.10",
     "@react-navigation/bottom-tabs": "^5.6.1",
     "@react-navigation/native": "^5.6.1",
@@ -36,10 +37,9 @@
     "react-native-gesture-handler": "~1.6.0",
     "react-native-safe-area-context": "~3.0.7",
     "react-native-screens": "~2.9.0",
-    "react-test-renderer": "~16.11.0",
-    "sharp-cli": "^1.14.1",
     "react-native-svg": "12.1.0",
-    "@react-native-community/async-storage": "~1.11.0"
+    "react-test-renderer": "~16.11.0",
+    "sharp-cli": "^1.14.1"
   },
   "devDependencies": {
     "@babel/core": "^7.10.4",
@@ -47,6 +47,7 @@
     "babel-preset-expo": "^8.2.3",
     "eslint": "^7.4.0",
     "eslint-plugin-react": "^7.20.3",
+    "eslint-plugin-react-hooks": "^4.0.8",
     "jest-expo": "^38.0.2",
     "react-native-testing-library": "^2.1.0"
   },

--- a/src/components/form/Input.jsx
+++ b/src/components/form/Input.jsx
@@ -11,7 +11,7 @@ const NiInput = ({ style, value, onChangeText, caption, type, darkMode }) => {
   const keyboradType = type === 'email' ? 'email-address' : 'default';
   const showPasswordIcon = showPassword ? 'eye' : 'eye-off';
   const secureTextEntry = isPassword && !showPassword;
-  const togglePassword = () => { setShowPassword(!showPassword); };
+  const togglePassword = () => { setShowPassword(showPassword => !showPassword); };
   const textStyle = { ...styles.text };
   const inputStyle = { ...styles.input };
   if (isPassword) inputStyle.paddingRight = 30;


### PR DESCRIPTION
Finalement j'ai tout mis dans un ticket parce qu'il n'y a pas beaucoup de changements

pour le eslint: on a des warning sur les useEffect qui ont pour deuxieme argument mais j'ai l'impression que c'est normal (cf la remarque de ce paragraphe https://fr.reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects )

pour ce qui est des bonnes pratiques du state (cf article). 
- pour le premier point: on n'en a pas 
- pour le deuxieme point: je n'ai vu que showPassword, je l'ai donc changé
- pour le troisieme point: j'ai l'impression qu'on a ce cas dans sendEmail (forgotPassword) mais on ne peut pas utiliser de useEffect a l'interieur d'une fonction. J'ai cherché mais je n'ai pas trouve la bonne pratique dans notre cas. Comme la suite du code ne depend pas vraiment du changement de state j'ai decide de laisser comme ca. 