### PR TITLE
Com 1434-2 + REFACTO

### DIFF
--- a/src/components/cards/AnswerTextArea.tsx
+++ b/src/components/cards/AnswerTextArea.tsx
@@ -5,10 +5,10 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import Shadow from '../../../components/style/Shadow';
-import { GREY, PINK, TRANSPARENT_PINK, WHITE } from '../../../styles/colors';
-import { BORDER_RADIUS, BORDER_WIDTH, MARGIN, PADDING, TEXT_AREA_HEIGHT } from '../../../styles/metrics';
-import { FIRA_SANS_MEDIUM, FIRA_SANS_REGULAR } from '../../../styles/fonts';
+import Shadow from '../style/Shadow';
+import { GREY, PINK, TRANSPARENT_PINK, WHITE } from '../../styles/colors';
+import { BORDER_RADIUS, BORDER_WIDTH, MARGIN, PADDING, TEXT_AREA_HEIGHT } from '../../styles/metrics';
+import { FIRA_SANS_MEDIUM, FIRA_SANS_REGULAR } from '../../styles/fonts';
 
 interface AnswerQuestionProps {
   answer: string,

--- a/src/components/cards/CardFooter.tsx
+++ b/src/components/cards/CardFooter.tsx
@@ -42,7 +42,6 @@ const styles = ({ justifyContent }: StylesProps) => StyleSheet.create({
     flexDirection: 'row',
     justifyContent,
     marginBottom: MARGIN.XL,
-    marginTop: MARGIN.LG,
     marginHorizontal: MARGIN.LG,
   },
 });

--- a/src/components/cards/QuestionCardFooter.tsx
+++ b/src/components/cards/QuestionCardFooter.tsx
@@ -69,7 +69,6 @@ const styles = (arrowButtonVisible: boolean) => StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     marginBottom: MARGIN.XL,
-    marginTop: MARGIN.LG,
     marginHorizontal: MARGIN.LG,
   },
   button: {

--- a/src/components/cards/QuizProposition.tsx
+++ b/src/components/cards/QuizProposition.tsx
@@ -78,7 +78,7 @@ const styles = (color: string, isSelected: boolean, isGoodAnswer: boolean, isVal
     color: isGoodAnswer ? GREEN['600'] : ORANGE['600'],
     fontSize: ICON.MD,
     alignSelf: 'center',
-    paddingVertical: PADDING.SM,
+    paddingVertical: PADDING.LG,
     paddingHorizontal: PADDING.MD,
     backgroundColor: !isValidated || isSelected || (isValidated && isGoodAnswer) ? WHITE : GREY['100'],
   },

--- a/src/components/cards/QuizProposition.tsx
+++ b/src/components/cards/QuizProposition.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, StyleSheet, TouchableOpacity, Text } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { MARGIN, BORDER_WIDTH, BORDER_RADIUS, ICON, PADDING } from '../../styles/metrics';
+import { MARGIN, BORDER_WIDTH, BORDER_RADIUS, ICON, PADDING, BUTTON_HEIGHT } from '../../styles/metrics';
 import { WHITE, GREY, GREEN, ORANGE, PINK } from '../../styles/colors';
 import Shadow from '../style/Shadow';
 import { FIRA_SANS_MEDIUM } from '../../styles/fonts';
@@ -62,6 +62,7 @@ const styles = (color: string, isSelected: boolean, isGoodAnswer: boolean, isVal
   },
   answer: {
     flexDirection: 'row',
+    minHeight: BUTTON_HEIGHT,
     borderWidth: BORDER_WIDTH,
     backgroundColor: !isValidated || isSelected || (isValidated && isGoodAnswer) ? WHITE : GREY['100'],
     borderColor: isSelected ? color : GREY['200'],
@@ -78,8 +79,7 @@ const styles = (color: string, isSelected: boolean, isGoodAnswer: boolean, isVal
     color: isGoodAnswer ? GREEN['600'] : ORANGE['600'],
     fontSize: ICON.MD,
     alignSelf: 'center',
-    paddingVertical: PADDING.LG,
-    paddingHorizontal: PADDING.MD,
+    padding: PADDING.MD,
     backgroundColor: !isValidated || isSelected || (isValidated && isGoodAnswer) ? WHITE : GREY['100'],
   },
   textContainer: {

--- a/src/components/style/FooterGradient.tsx
+++ b/src/components/style/FooterGradient.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { GREY, TRANSPARENT_GRADIENT } from '../../styles/colors';
-import { BUTTON_HEIGHT, INPUT_HEIGHT, MARGIN } from '../../styles/metrics';
+import { ABSOLUTE_BOTTOM_POSITION, INPUT_HEIGHT } from '../../styles/metrics';
 
 const FooterGradient = () => (
   <LinearGradient style={styles.gradient} colors={[TRANSPARENT_GRADIENT, GREY[100]]} />
@@ -14,7 +14,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     right: 0,
     left: 0,
-    bottom: BUTTON_HEIGHT + MARGIN.XL,
+    bottom: ABSOLUTE_BOTTOM_POSITION,
   },
 });
 

--- a/src/components/style/FooterGradient.tsx
+++ b/src/components/style/FooterGradient.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { GREY, TRANSPARENT_GRADIENT } from '../../styles/colors';
+import { BUTTON_HEIGHT, INPUT_HEIGHT, MARGIN } from '../../styles/metrics';
+
+const FooterGradient = () => (
+  <LinearGradient style={styles.gradient} colors={[TRANSPARENT_GRADIENT, GREY[100]]} />
+);
+
+const styles = StyleSheet.create({
+  gradient: {
+    height: INPUT_HEIGHT,
+    position: 'absolute',
+    right: 0,
+    left: 0,
+    bottom: BUTTON_HEIGHT + MARGIN.XL,
+  },
+});
+
+export default FooterGradient;

--- a/src/screens/courses/cardTemplates/FlashCard.tsx
+++ b/src/screens/courses/cardTemplates/FlashCard.tsx
@@ -92,7 +92,7 @@ const FlashCard = ({ card, index }: FlashCard) => {
 const styles = StyleSheet.create({
   container: {
     marginHorizontal: MARGIN.LG,
-    marginVertical: IS_LARGE_SCREEN ? MARGIN.XXL : MARGIN.MD,
+    marginVertical: IS_LARGE_SCREEN ? MARGIN.XXL : MARGIN.LG,
     alignItems: 'center',
     justifyContent: 'center',
     flexGrow: 1,

--- a/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard.tsx
@@ -8,12 +8,13 @@ import { getCard } from '../../../store/activities/selectors';
 import CardHeader from '../../../components/cards/CardHeader';
 import { FIRA_SANS_REGULAR } from '../../../styles/fonts';
 import { GREEN, GREY, ORANGE, PINK } from '../../../styles/colors';
-import { MARGIN } from '../../../styles/metrics';
+import { BUTTON_HEIGHT, INPUT_HEIGHT, MARGIN } from '../../../styles/metrics';
 import QuestionCardFooter from '../../../components/cards/QuestionCardFooter';
 import { MULTIPLE_CHOICE_QUESTION } from '../../../core/data/constants';
 import { navigate } from '../../../navigationRef';
 import QuizProposition from '../../../components/cards/QuizProposition';
 import cardsStyle from '../../../styles/cards';
+import FooterGradient from '../../../components/style/FooterGradient';
 
 interface MultipleChoiceQuestionCardProps {
   card: MultipleChoiceQuestionType,
@@ -100,6 +101,7 @@ const MultipleChoiceQuestionCard = ({ card, cardIndex }: MultipleChoiceQuestionC
         </View>
       </ScrollView>
       <View style={style.footerContainer}>
+        {!isValidated && <FooterGradient /> }
         {isValidated && <Text style={[cardsStyle.explanation, style.explanation]}>{card.explanation}</Text>}
         <QuestionCardFooter onPressButton={onPressFooterButton} buttonCaption={isValidated ? 'Continuer' : 'Valider'}
           arrowColor={footerColors.buttonsColor} index={cardIndex} buttonDisabled={!isOneAnswerSelected()}
@@ -123,6 +125,12 @@ const styles = (textColor: string, backgroundColor: string) => StyleSheet.create
   },
   explanation: {
     color: textColor,
+    minHeight: INPUT_HEIGHT,
+    position: 'absolute',
+    right: 0,
+    left: 0,
+    bottom: BUTTON_HEIGHT + MARGIN.XL,
+    backgroundColor,
   },
   footerContainer: {
     backgroundColor,

--- a/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard.tsx
@@ -8,7 +8,7 @@ import { getCard } from '../../../store/activities/selectors';
 import CardHeader from '../../../components/cards/CardHeader';
 import { FIRA_SANS_REGULAR } from '../../../styles/fonts';
 import { GREEN, GREY, ORANGE, PINK } from '../../../styles/colors';
-import { BUTTON_HEIGHT, INPUT_HEIGHT, MARGIN } from '../../../styles/metrics';
+import { ABSOLUTE_BOTTOM_POSITION, INPUT_HEIGHT, MARGIN } from '../../../styles/metrics';
 import QuestionCardFooter from '../../../components/cards/QuestionCardFooter';
 import { MULTIPLE_CHOICE_QUESTION } from '../../../core/data/constants';
 import { navigate } from '../../../navigationRef';
@@ -129,7 +129,7 @@ const styles = (textColor: string, backgroundColor: string) => StyleSheet.create
     position: 'absolute',
     right: 0,
     left: 0,
-    bottom: BUTTON_HEIGHT + MARGIN.XL,
+    bottom: ABSOLUTE_BOTTOM_POSITION,
     backgroundColor,
   },
   footerContainer: {

--- a/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard.tsx
@@ -8,7 +8,7 @@ import { getCard } from '../../../store/activities/selectors';
 import CardHeader from '../../../components/cards/CardHeader';
 import { FIRA_SANS_REGULAR } from '../../../styles/fonts';
 import { GREEN, GREY, ORANGE, PINK } from '../../../styles/colors';
-import { ABSOLUTE_BOTTOM_POSITION, INPUT_HEIGHT, MARGIN } from '../../../styles/metrics';
+import { ABSOLUTE_BOTTOM_POSITION, INPUT_HEIGHT, MARGIN, PADDING } from '../../../styles/metrics';
 import QuestionCardFooter from '../../../components/cards/QuestionCardFooter';
 import { MULTIPLE_CHOICE_QUESTION } from '../../../core/data/constants';
 import { navigate } from '../../../navigationRef';
@@ -116,7 +116,7 @@ const styles = (textColor: string, backgroundColor: string) => StyleSheet.create
     marginHorizontal: MARGIN.LG,
     flexGrow: 1,
     justifyContent: 'space-between',
-    marginBottom: MARGIN.LG,
+    paddingBottom: PADDING.XL,
   },
   informativeText: {
     ...FIRA_SANS_REGULAR.SM,

--- a/src/screens/courses/cardTemplates/OpenQuestion.tsx
+++ b/src/screens/courses/cardTemplates/OpenQuestion.tsx
@@ -10,7 +10,7 @@ import { GREY, PINK } from '../../../styles/colors';
 import { IS_LARGE_SCREEN, MARGIN } from '../../../styles/metrics';
 import QuestionCardFooter from '../../../components/cards/QuestionCardFooter';
 import { OPEN_QUESTION } from '../../../core/data/constants';
-import AnswerTextArea from './AnswerTextArea';
+import AnswerTextArea from '../../../components/cards/AnswerTextArea';
 import { QuestionnaireAnswerType } from '../../../types/store/ActivityStoreType';
 import Actions from '../../../store/activities/actions';
 

--- a/src/screens/courses/cardTemplates/OpenQuestion.tsx
+++ b/src/screens/courses/cardTemplates/OpenQuestion.tsx
@@ -62,6 +62,7 @@ const styles = (isSelected: boolean) => StyleSheet.create({
   },
   container: {
     flexGrow: 1,
+    marginBottom: MARGIN.LG,
   },
   question: {
     ...FIRA_SANS_REGULAR.LG,

--- a/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
@@ -7,7 +7,7 @@ import { StateType } from '../../../types/store/StoreType';
 import { getCard } from '../../../store/activities/selectors';
 import CardHeader from '../../../components/cards/CardHeader';
 import { GREY, GREEN, ORANGE, PINK } from '../../../styles/colors';
-import { ABSOLUTE_BOTTOM_POSITION, INPUT_HEIGHT, MARGIN } from '../../../styles/metrics';
+import { ABSOLUTE_BOTTOM_POSITION, INPUT_HEIGHT, MARGIN, PADDING } from '../../../styles/metrics';
 import QuestionCardFooter from '../../../components/cards/QuestionCardFooter';
 import QuizProposition from '../../../components/cards/QuizProposition';
 import { SINGLE_CHOICE_QUESTION } from '../../../core/data/constants';
@@ -73,7 +73,7 @@ const styles = (isPressed: boolean, backgroundColor: string, textColor: string) 
     marginHorizontal: MARGIN.LG,
     flexGrow: 1,
     justifyContent: 'space-between',
-    marginBottom: MARGIN.LG,
+    paddingBottom: PADDING.XL,
   },
   explanation: {
     color: textColor,

--- a/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
@@ -7,7 +7,7 @@ import { StateType } from '../../../types/store/StoreType';
 import { getCard } from '../../../store/activities/selectors';
 import CardHeader from '../../../components/cards/CardHeader';
 import { GREY, GREEN, ORANGE, PINK } from '../../../styles/colors';
-import { BUTTON_HEIGHT, INPUT_HEIGHT, MARGIN } from '../../../styles/metrics';
+import { ABSOLUTE_BOTTOM_POSITION, INPUT_HEIGHT, MARGIN } from '../../../styles/metrics';
 import QuestionCardFooter from '../../../components/cards/QuestionCardFooter';
 import QuizProposition from '../../../components/cards/QuizProposition';
 import { SINGLE_CHOICE_QUESTION } from '../../../core/data/constants';
@@ -81,7 +81,7 @@ const styles = (isPressed: boolean, backgroundColor: string, textColor: string) 
     position: 'absolute',
     right: 0,
     left: 0,
-    bottom: BUTTON_HEIGHT + MARGIN.XL,
+    bottom: ABSOLUTE_BOTTOM_POSITION,
     backgroundColor,
   },
   footerContainer: {

--- a/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
@@ -7,11 +7,12 @@ import { StateType } from '../../../types/store/StoreType';
 import { getCard } from '../../../store/activities/selectors';
 import CardHeader from '../../../components/cards/CardHeader';
 import { GREY, GREEN, ORANGE, PINK } from '../../../styles/colors';
-import { MARGIN } from '../../../styles/metrics';
+import { BUTTON_HEIGHT, INPUT_HEIGHT, MARGIN } from '../../../styles/metrics';
 import QuestionCardFooter from '../../../components/cards/QuestionCardFooter';
 import QuizProposition from '../../../components/cards/QuizProposition';
 import { SINGLE_CHOICE_QUESTION } from '../../../core/data/constants';
 import cardsStyle from '../../../styles/cards';
+import FooterGradient from '../../../components/style/FooterGradient';
 
 interface SingleChoiceQuestionCardProps {
   card: SingleChoiceQuestionType,
@@ -58,6 +59,7 @@ const SingleChoiceQuestionCard = ({ card, index }: SingleChoiceQuestionCardProps
         </View>
       </ScrollView>
       <View style={style.footerContainer}>
+        {!isPressed && <FooterGradient /> }
         {isPressed && <Text style={[cardsStyle.explanation, style.explanation]}>{card.explanation}</Text>}
         <QuestionCardFooter index={index} arrowColor={isPressed ? expectedColors.button : PINK['500']}
           buttonVisible={isPressed} buttonColor={isPressed ? expectedColors.button : GREY['300']} />
@@ -75,6 +77,12 @@ const styles = (isPressed: boolean, backgroundColor: string, textColor: string) 
   },
   explanation: {
     color: textColor,
+    minHeight: INPUT_HEIGHT,
+    position: 'absolute',
+    right: 0,
+    left: 0,
+    bottom: BUTTON_HEIGHT + MARGIN.XL,
+    backgroundColor,
   },
   footerContainer: {
     backgroundColor: isPressed ? backgroundColor : GREY['100'],

--- a/src/screens/courses/cardTemplates/TextMediaCard.tsx
+++ b/src/screens/courses/cardTemplates/TextMediaCard.tsx
@@ -50,6 +50,7 @@ const styles = (imgHeight: number) => StyleSheet.create({
   container: {
     flex: 1,
     marginHorizontal: MARGIN.MD,
+    marginBottom: MARGIN.LG,
   },
   image: {
     ...cardsStyle.media,

--- a/src/screens/courses/cardTemplates/TitleTextCard.tsx
+++ b/src/screens/courses/cardTemplates/TitleTextCard.tsx
@@ -34,6 +34,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     marginHorizontal: MARGIN.MD,
+    marginBottom: MARGIN.LG,
   },
 });
 

--- a/src/screens/courses/cardTemplates/TitleTextMediaCard.tsx
+++ b/src/screens/courses/cardTemplates/TitleTextMediaCard.tsx
@@ -51,6 +51,7 @@ const styles = (imgHeight : number) => StyleSheet.create({
   container: {
     flex: 1,
     marginHorizontal: MARGIN.MD,
+    marginBottom: MARGIN.LG,
   },
   image: {
     ...cardsStyle.media,

--- a/src/styles/cards.ts
+++ b/src/styles/cards.ts
@@ -1,7 +1,7 @@
 import { StyleSheet } from 'react-native';
 import { GREY } from './colors';
 import { FIRA_SANS_REGULAR, FIRA_SANS_BLACK, FIRA_SANS_MEDIUM } from './fonts';
-import { BORDER_RADIUS, MARGIN } from './metrics';
+import { BORDER_RADIUS, MARGIN, PADDING } from './metrics';
 
 export default StyleSheet.create({
   title: {
@@ -24,8 +24,7 @@ export default StyleSheet.create({
   explanation: {
     ...FIRA_SANS_REGULAR.MD,
     textAlign: 'justify',
-    marginHorizontal: MARGIN.LG,
-    marginTop: MARGIN.MD,
-    marginBottom: -MARGIN.SM,
+    paddingHorizontal: PADDING.XL,
+    paddingVertical: PADDING.LG,
   },
 });

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -82,5 +82,6 @@ export const GREY = {
 export const WHITE = 'white';
 export const TRANSPARENT_GREY = 'rgba(31, 20, 27, 0.2)';
 export const TRANSPARENT_PINK = 'rgba(193, 40, 98, 0.2)';
+export const TRANSPARENT_GRADIENT = '#FFFFFF00';
 export const MODAL_BACKDROP_GREY = '#00000040';
 export const RED = '#FF0000';

--- a/src/styles/metrics.ts
+++ b/src/styles/metrics.ts
@@ -51,6 +51,7 @@ export const IS_SMALL_SCREEN = Platform.select({
 
 export const INPUT_HEIGHT = 40;
 export const BUTTON_HEIGHT = 48;
+export const ABSOLUTE_BOTTOM_POSITION = BUTTON_HEIGHT + MARGIN.XL;
 export const COURSE_CELL_WIDTH = IS_SMALL_SCREEN ? 230 : 250;
 export const SMALL_SCREEN_MAX_HEIGHT = 568;
 export const IS_LARGE_SCREEN = SCREEN_HEIGHT > SMALL_SCREEN_MAX_HEIGHT;


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- Cas d'usage : 
gradient sur qcu et qcm pour sous-entendre qu'il faut scroller
lorsque l'explication apparait sur qcu et qcm, les réponses ne montent plus et passent sous l'explication (vu avec Romain)
marginTop n'a rien à faire dans les footer (questioncardfooter et cardfooter), je l'ai retiré et ajouté un marginBottom sur les cartes (vérifier que le margin est présent sur les différentes cartes (qcu, qcm, titletext, titlemedia, titletextmedia, sondage, flashcard, open question)