### PR TITLE
change permission

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,7 +24,8 @@
     },
     "android": {
       "package": "com.alenvi.compani",
-      "versionCode": 14
+      "permissions": [],
+      "versionCode": 23
     }
   }
 }


### PR DESCRIPTION
- [ ] J'ai testé sur iphone -np
- [x] J'ai testé sur android

- Cas d'usage : Il fallait ajouter `permissions: []` dans app.json pour demander le moins de permissions possibles a l'utilisateur. Par defaut on en demandait 50 (dont la localisation par exemple). Maintenant c'est descendu a 22. 
