### PR TITLE
Com 1518

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,7 +25,7 @@
     "android": {
       "package": "com.alenvi.compani",
       "permissions": [],
-      "versionCode": 23
+      "versionCode": 25
     }
   }
 }

--- a/src/AppContainer.tsx
+++ b/src/AppContainer.tsx
@@ -19,7 +19,7 @@ import CardContainer from './screens/courses/CardContainer';
 import MainActions from './store/main/actions';
 import Actions from './store/actions';
 import { PINK } from './styles/colors';
-import { ActionType, ResetType } from './types/store/StoreType';
+import { ActionType, ActionWithoutPayloadType } from './types/store/StoreType';
 import Users from './api/users';
 import { UserType } from './types/UserType';
 
@@ -107,7 +107,7 @@ const AppContainer = ({ setLoggedUser, resetAllReducers }: AppContainerProps) =>
   );
 };
 
-const mapDispatchToProps = (dispatch: ({ type }: ActionType | ResetType) => void) => ({
+const mapDispatchToProps = (dispatch: ({ type }: ActionType | ActionWithoutPayloadType) => void) => ({
   setLoggedUser: (user: UserType) => dispatch(MainActions.setLoggedUser(user)),
   resetAllReducers: () => dispatch(Actions.resetAllReducers()),
 });

--- a/src/screens/courses/cardTemplates/EndCard.tsx
+++ b/src/screens/courses/cardTemplates/EndCard.tsx
@@ -18,6 +18,7 @@ interface EndCardProps {
   courseId: String,
   activity: ActivityType,
   questionnaireAnswersList: Array<QuestionnaireAnswerType>,
+  score: number,
   resetActivityReducer: () => void,
   setCardIndex: (number) => void,
 }
@@ -26,6 +27,7 @@ const EndCard = ({
   courseId,
   activity,
   questionnaireAnswersList,
+  score,
   setCardIndex,
   resetActivityReducer,
 }: EndCardProps) => {
@@ -34,7 +36,7 @@ const EndCard = ({
   useEffect(() => {
     async function fetchData() {
       const userId = await AsyncStorage.getItem('user_id');
-      const payload: Record<string, any> = { user: userId, activity: activity._id };
+      const payload: Record<string, any> = { user: userId, activity: activity._id, score };
 
       if (questionnaireAnswersList?.length) payload.questionnaireAnswersList = questionnaireAnswersList;
       await ActivityHistories.createActivityHistories(payload);
@@ -42,7 +44,7 @@ const EndCard = ({
     }
 
     if (isFocused) fetchData();
-  }, [isFocused, activity, questionnaireAnswersList, setCardIndex]);
+  }, [isFocused, activity, questionnaireAnswersList, setCardIndex, score]);
 
   const goBack = () => {
     navigate('Home', { screen: 'Courses', params: { screen: 'CourseProfile', params: { courseId } } });
@@ -93,6 +95,7 @@ const styles = StyleSheet.create({
 const mapStateToProps = (state: StateType) => ({
   activity: state.activities.activity,
   questionnaireAnswersList: state.activities.questionnaireAnswersList,
+  score: state.activities.score,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import shuffle from 'lodash/shuffle';
 import { MultipleChoiceQuestionType, qcmAnswerFromAPIType } from '../../../types/CardType';
 import { StateType } from '../../../types/store/StoreType';
-import { ActivityActionType } from '../../../types/store/ActivityStoreType';
+import { IncGoodAnswersCountType } from '../../../types/store/ActivityStoreType';
 import { getCard } from '../../../store/activities/selectors';
 import Actions from '../../../store/activities/actions';
 import CardHeader from '../../../components/cards/CardHeader';
@@ -146,7 +146,7 @@ const styles = (textColor: string, backgroundColor: string) => StyleSheet.create
 });
 
 const mapStateToProps = (state: StateType) => ({ card: getCard(state), cardIndex: state.activities.cardIndex });
-const mapDispatchToProps = (dispatch: ({ type }: ActivityActionType) => void) => ({
+const mapDispatchToProps = (dispatch: ({ type }: IncGoodAnswersCountType) => void) => ({
   incGoodAnswersCount: () => dispatch(Actions.incGoodAnswersCount()),
 });
 

--- a/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import shuffle from 'lodash/shuffle';
 import { MultipleChoiceQuestionType, qcmAnswerFromAPIType } from '../../../types/CardType';
 import { StateType } from '../../../types/store/StoreType';
-import { IncGoodAnswersCountType } from '../../../types/store/ActivityStoreType';
 import { getCard } from '../../../store/activities/selectors';
 import Actions from '../../../store/activities/actions';
 import CardHeader from '../../../components/cards/CardHeader';

--- a/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard.tsx
@@ -81,6 +81,7 @@ const MultipleChoiceQuestionCard = ({ card, cardIndex, incGoodAnswersCount }: Mu
         (answer.isSelected && answer.correct) || (!answer.isSelected && !answer.correct));
       setIsAnsweredCorrectly(areAnswersCorrect);
       if (areAnswersCorrect) incGoodAnswersCount();
+
       return setIsValidated(true);
     }
 
@@ -146,7 +147,7 @@ const styles = (textColor: string, backgroundColor: string) => StyleSheet.create
 });
 
 const mapStateToProps = (state: StateType) => ({ card: getCard(state), cardIndex: state.activities.cardIndex });
-const mapDispatchToProps = (dispatch: ({ type }: IncGoodAnswersCountType) => void) => ({
+const mapDispatchToProps = dispatch => ({
   incGoodAnswersCount: () => dispatch(Actions.incGoodAnswersCount()),
 });
 

--- a/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
@@ -4,7 +4,9 @@ import { connect } from 'react-redux';
 import shuffle from 'lodash/shuffle';
 import { SingleChoiceQuestionType } from '../../../types/CardType';
 import { StateType } from '../../../types/store/StoreType';
+import { ActivityActionType } from '../../../types/store/ActivityStoreType';
 import { getCard } from '../../../store/activities/selectors';
+import Actions from '../../../store/activities/actions';
 import CardHeader from '../../../components/cards/CardHeader';
 import { GREY, GREEN, ORANGE, PINK } from '../../../styles/colors';
 import { ABSOLUTE_BOTTOM_POSITION, INPUT_HEIGHT, MARGIN, PADDING } from '../../../styles/metrics';
@@ -17,9 +19,10 @@ import FooterGradient from '../../../components/style/FooterGradient';
 interface SingleChoiceQuestionCardProps {
   card: SingleChoiceQuestionType,
   index: number,
+  incGoodAnswersCount: () => void,
 }
 
-const SingleChoiceQuestionCard = ({ card, index }: SingleChoiceQuestionCardProps) => {
+const SingleChoiceQuestionCard = ({ card, index, incGoodAnswersCount }: SingleChoiceQuestionCardProps) => {
   const [isPressed, setIsPressed] = useState<boolean>(false);
   const [selectedAnswerIndex, setSelectedAnswerIndex] = useState<number>(-1);
   const [answers, setAnswers] = useState<string[]>([]);
@@ -35,6 +38,7 @@ const SingleChoiceQuestionCard = ({ card, index }: SingleChoiceQuestionCardProps
   const onSelectAnswer = (selectedIndex) => {
     setIsPressed(true);
     setSelectedAnswerIndex(selectedIndex);
+    if (answers[selectedIndex] === card.qcuGoodAnswer) incGoodAnswersCount();
   };
 
   const expectedColors = answers[selectedAnswerIndex] === card.qcuGoodAnswer
@@ -91,4 +95,8 @@ const styles = (isPressed: boolean, backgroundColor: string, textColor: string) 
 
 const mapStateToProps = (state: StateType) => ({ card: getCard(state), index: state.activities.cardIndex });
 
-export default connect(mapStateToProps)(SingleChoiceQuestionCard);
+const mapDispatchToProps = (dispatch: ({ type }: ActivityActionType) => void) => ({
+  incGoodAnswersCount: () => dispatch(Actions.incGoodAnswersCount()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(SingleChoiceQuestionCard);

--- a/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
@@ -95,7 +95,7 @@ const styles = (isPressed: boolean, backgroundColor: string, textColor: string) 
 
 const mapStateToProps = (state: StateType) => ({ card: getCard(state), index: state.activities.cardIndex });
 
-const mapDispatchToProps = (dispatch: ({ type }: IncGoodAnswersCountType) => void) => ({
+const mapDispatchToProps = dispatch => ({
   incGoodAnswersCount: () => dispatch(Actions.incGoodAnswersCount()),
 });
 

--- a/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import shuffle from 'lodash/shuffle';
 import { SingleChoiceQuestionType } from '../../../types/CardType';
 import { StateType } from '../../../types/store/StoreType';
-import { ActivityActionType } from '../../../types/store/ActivityStoreType';
+import { IncGoodAnswersCountType } from '../../../types/store/ActivityStoreType';
 import { getCard } from '../../../store/activities/selectors';
 import Actions from '../../../store/activities/actions';
 import CardHeader from '../../../components/cards/CardHeader';
@@ -95,7 +95,7 @@ const styles = (isPressed: boolean, backgroundColor: string, textColor: string) 
 
 const mapStateToProps = (state: StateType) => ({ card: getCard(state), index: state.activities.cardIndex });
 
-const mapDispatchToProps = (dispatch: ({ type }: ActivityActionType) => void) => ({
+const mapDispatchToProps = (dispatch: ({ type }: IncGoodAnswersCountType) => void) => ({
   incGoodAnswersCount: () => dispatch(Actions.incGoodAnswersCount()),
 });
 

--- a/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
+++ b/src/screens/courses/cardTemplates/SingleChoiceQuestionCard.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import shuffle from 'lodash/shuffle';
 import { SingleChoiceQuestionType } from '../../../types/CardType';
 import { StateType } from '../../../types/store/StoreType';
-import { IncGoodAnswersCountType } from '../../../types/store/ActivityStoreType';
 import { getCard } from '../../../store/activities/selectors';
 import Actions from '../../../store/activities/actions';
 import CardHeader from '../../../components/cards/CardHeader';

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,5 +1,5 @@
-import { LOG_OUT, ResetType } from '../types/store/StoreType';
+import { LOG_OUT, ActionWithoutPayloadType } from '../types/store/StoreType';
 
-const resetAllReducers = (): ResetType => ({ type: LOG_OUT });
+const resetAllReducers = (): ActionWithoutPayloadType => ({ type: LOG_OUT });
 
 export default { resetAllReducers };

--- a/src/store/activities/actions.ts
+++ b/src/store/activities/actions.ts
@@ -1,4 +1,4 @@
-import { ResetType } from '../../types/store/StoreType';
+import { ActionWithoutPayloadType } from '../../types/store/StoreType';
 import {
   SET_ACTIVITY,
   SET_CARD_INDEX,
@@ -23,7 +23,7 @@ const setExitConfirmationModal = (exitConfirmationModal: boolean): SetExitConfir
   ({ type: SET_EXIT_CONFIRMATION_MODAL, payload: exitConfirmationModal });
 const addQuestionnaireAnswer = (questionnaireAnswer: QuestionnaireAnswerType): AddQuestionnaireAnswerType =>
   ({ type: ADD_QUESTIONNAIRE_ANSWER, payload: questionnaireAnswer });
-const resetActivityReducer = (): ResetType => ({ type: RESET_ACTIVITY_REDUCER });
+const resetActivityReducer = (): ActionWithoutPayloadType => ({ type: RESET_ACTIVITY_REDUCER });
 const setQuestionnaireAnswersList =
   (questionnaireAnswersList: Array<QuestionnaireAnswerType>): SetQuestionnaireAnswersListType =>
     ({ type: SET_QUESTIONNAIRE_ANSWERS_LIST, payload: questionnaireAnswersList });

--- a/src/store/activities/actions.ts
+++ b/src/store/activities/actions.ts
@@ -12,7 +12,6 @@ import {
   AddQuestionnaireAnswerType,
   SetQuestionnaireAnswersListType,
   SET_QUESTIONNAIRE_ANSWERS_LIST,
-  IncGoodAnswersCountType,
   INC_GOOD_ANSWERS_COUNT,
 } from '../../types/store/ActivityStoreType';
 import { ActivityType } from '../../types/ActivityType';
@@ -27,7 +26,7 @@ const resetActivityReducer = (): ActionWithoutPayloadType => ({ type: RESET_ACTI
 const setQuestionnaireAnswersList =
   (questionnaireAnswersList: Array<QuestionnaireAnswerType>): SetQuestionnaireAnswersListType =>
     ({ type: SET_QUESTIONNAIRE_ANSWERS_LIST, payload: questionnaireAnswersList });
-const incGoodAnswersCount = (): IncGoodAnswersCountType => ({ type: INC_GOOD_ANSWERS_COUNT });
+const incGoodAnswersCount = (): ActionWithoutPayloadType => ({ type: INC_GOOD_ANSWERS_COUNT });
 
 export default {
   setActivity,

--- a/src/store/activities/actions.ts
+++ b/src/store/activities/actions.ts
@@ -12,6 +12,8 @@ import {
   AddQuestionnaireAnswerType,
   SetQuestionnaireAnswersListType,
   SET_QUESTIONNAIRE_ANSWERS_LIST,
+  IncGoodAnswersCountType,
+  INC_GOOD_ANSWERS_COUNT,
 } from '../../types/store/ActivityStoreType';
 import { ActivityType } from '../../types/ActivityType';
 
@@ -25,6 +27,7 @@ const resetActivityReducer = (): ResetType => ({ type: RESET_ACTIVITY_REDUCER })
 const setQuestionnaireAnswersList =
   (questionnaireAnswersList: Array<QuestionnaireAnswerType>): SetQuestionnaireAnswersListType =>
     ({ type: SET_QUESTIONNAIRE_ANSWERS_LIST, payload: questionnaireAnswersList });
+const incGoodAnswersCount = (): IncGoodAnswersCountType => ({ type: INC_GOOD_ANSWERS_COUNT });
 
 export default {
   setActivity,
@@ -33,4 +36,5 @@ export default {
   addQuestionnaireAnswer,
   resetActivityReducer,
   setQuestionnaireAnswersList,
+  incGoodAnswersCount,
 };

--- a/src/store/activities/reducers.ts
+++ b/src/store/activities/reducers.ts
@@ -8,12 +8,27 @@ import {
   ADD_QUESTIONNAIRE_ANSWER,
   SET_QUESTIONNAIRE_ANSWERS_LIST,
 } from '../../types/store/ActivityStoreType';
+import { CARD_TEMPLATES, QUIZ } from '../../core/data/constants';
 
 const initialState: ActivityStateType = {
   activity: null,
   cardIndex: null,
   exitConfirmationModal: false,
   questionnaireAnswersList: [],
+  score: {
+    goodAnswersCount: 0,
+    quizCount: 0,
+  },
+};
+
+const applySetActivities = (state, action) => {
+  const activity = action.payload;
+  const count = activity?.cards?.filter((card) => {
+    const template = CARD_TEMPLATES.find(t => card.template === t.value);
+    if (template?.type === QUIZ) return true;
+    return false;
+  }).length;
+  return { ...state, activity, score: { ...state.score, quizCount: count || 0 } };
 };
 
 const applyAddQuestionnaireAnswer = (state, action) => {
@@ -37,7 +52,7 @@ export const activities = (
 ): ActivityStateType => {
   switch (action.type) {
     case SET_ACTIVITY:
-      return { ...state, activity: action.payload };
+      return applySetActivities(state, action);
     case SET_CARD_INDEX:
       return { ...state, cardIndex: action.payload };
     case SET_EXIT_CONFIRMATION_MODAL:

--- a/src/store/activities/reducers.ts
+++ b/src/store/activities/reducers.ts
@@ -1,4 +1,3 @@
-import { ActionType, ResetType } from '../../types/store/StoreType';
 import {
   ActivityStateType,
   SET_ACTIVITY,
@@ -8,7 +7,8 @@ import {
   ADD_QUESTIONNAIRE_ANSWER,
   SET_QUESTIONNAIRE_ANSWERS_LIST,
   INC_GOOD_ANSWERS_COUNT,
-  IncGoodAnswersCountType,
+  ActivityActionType,
+  ActivityActionWithoutPayloadType,
 } from '../../types/store/ActivityStoreType';
 
 const initialState: ActivityStateType = {
@@ -36,7 +36,7 @@ const applyAddQuestionnaireAnswer = (state, action) => {
 
 export const activities = (
   state: ActivityStateType = initialState,
-  action: ActionType | ResetType | IncGoodAnswersCountType
+  action: ActivityActionType | ActivityActionWithoutPayloadType
 ): ActivityStateType => {
   switch (action.type) {
     case SET_ACTIVITY:

--- a/src/store/activities/reducers.ts
+++ b/src/store/activities/reducers.ts
@@ -7,6 +7,7 @@ import {
   RESET_ACTIVITY_REDUCER,
   ADD_QUESTIONNAIRE_ANSWER,
   SET_QUESTIONNAIRE_ANSWERS_LIST,
+  INC_GOOD_ANSWERS_COUNT,
 } from '../../types/store/ActivityStoreType';
 import { CARD_TEMPLATES, QUIZ } from '../../core/data/constants';
 
@@ -63,6 +64,8 @@ export const activities = (
       return initialState;
     case SET_QUESTIONNAIRE_ANSWERS_LIST:
       return { ...state, questionnaireAnswersList: action.payload };
+    case INC_GOOD_ANSWERS_COUNT:
+      return { ...state, score: { ...state.score, goodAnswersCount: state.score.goodAnswersCount + 1 } };
     default:
       return state;
   }

--- a/src/store/activities/reducers.ts
+++ b/src/store/activities/reducers.ts
@@ -8,8 +8,8 @@ import {
   ADD_QUESTIONNAIRE_ANSWER,
   SET_QUESTIONNAIRE_ANSWERS_LIST,
   INC_GOOD_ANSWERS_COUNT,
+  IncGoodAnswersCountType,
 } from '../../types/store/ActivityStoreType';
-import { CARD_TEMPLATES, QUIZ } from '../../core/data/constants';
 
 const initialState: ActivityStateType = {
   activity: null,
@@ -36,7 +36,7 @@ const applyAddQuestionnaireAnswer = (state, action) => {
 
 export const activities = (
   state: ActivityStateType = initialState,
-  action: ActionType | ResetType
+  action: ActionType | ResetType | IncGoodAnswersCountType
 ): ActivityStateType => {
   switch (action.type) {
     case SET_ACTIVITY:

--- a/src/store/activities/reducers.ts
+++ b/src/store/activities/reducers.ts
@@ -16,20 +16,7 @@ const initialState: ActivityStateType = {
   cardIndex: null,
   exitConfirmationModal: false,
   questionnaireAnswersList: [],
-  score: {
-    goodAnswersCount: 0,
-    quizCount: 0,
-  },
-};
-
-const applySetActivities = (state, action) => {
-  const activity = action.payload;
-  const count = activity?.cards?.filter((card) => {
-    const template = CARD_TEMPLATES.find(t => card.template === t.value);
-    if (template?.type === QUIZ) return true;
-    return false;
-  }).length;
-  return { ...state, activity, score: { ...state.score, quizCount: count || 0 } };
+  score: 0,
 };
 
 const applyAddQuestionnaireAnswer = (state, action) => {
@@ -53,7 +40,7 @@ export const activities = (
 ): ActivityStateType => {
   switch (action.type) {
     case SET_ACTIVITY:
-      return applySetActivities(state, action);
+      return { ...state, activity: action.payload };
     case SET_CARD_INDEX:
       return { ...state, cardIndex: action.payload };
     case SET_EXIT_CONFIRMATION_MODAL:
@@ -65,7 +52,7 @@ export const activities = (
     case SET_QUESTIONNAIRE_ANSWERS_LIST:
       return { ...state, questionnaireAnswersList: action.payload };
     case INC_GOOD_ANSWERS_COUNT:
-      return { ...state, score: { ...state.score, goodAnswersCount: state.score.goodAnswersCount + 1 } };
+      return { ...state, score: state.score + 1 };
     default:
       return state;
   }

--- a/src/store/main/actions.ts
+++ b/src/store/main/actions.ts
@@ -1,9 +1,9 @@
 import { SET_LOGGED_USER, SetLoggedUserType, RESET_MAIN_REDUCER } from '../../types/store/MainStoreType';
-import { ResetType } from '../../types/store/StoreType';
+import { ActionWithoutPayloadType } from '../../types/store/StoreType';
 import { UserType } from '../../types/UserType';
 
 const setLoggedUser = (user: UserType): SetLoggedUserType => ({ type: SET_LOGGED_USER, payload: user });
-const resetMainReducer = (): ResetType => ({ type: RESET_MAIN_REDUCER });
+const resetMainReducer = (): ActionWithoutPayloadType => ({ type: RESET_MAIN_REDUCER });
 
 export default {
   setLoggedUser,

--- a/src/store/main/reducers.ts
+++ b/src/store/main/reducers.ts
@@ -1,9 +1,17 @@
-import { MainStateType, SET_LOGGED_USER, RESET_MAIN_REDUCER } from '../../types/store/MainStoreType';
-import { ActionType, ResetType } from '../../types/store/StoreType';
+import {
+  MainStateType,
+  SET_LOGGED_USER,
+  RESET_MAIN_REDUCER,
+  MainActionType,
+  ResetMainReducer,
+} from '../../types/store/MainStoreType';
 
 const initialState: MainStateType = { loggedUser: null };
 
-export const main = (state: MainStateType = initialState, action: ActionType | ResetType): MainStateType => {
+export const main = (
+  state: MainStateType = initialState,
+  action: MainActionType | ResetMainReducer
+): MainStateType => {
   switch (action.type) {
     case SET_LOGGED_USER:
       return { ...state, loggedUser: action.payload };

--- a/src/types/store/ActivityStoreType.ts
+++ b/src/types/store/ActivityStoreType.ts
@@ -7,6 +7,7 @@ export const SET_EXIT_CONFIRMATION_MODAL = 'SET_EXIT_CONFIRMATION_MODAL';
 export const ADD_QUESTIONNAIRE_ANSWER = 'ADD_QUESTIONNAIRE_ANSWER';
 export const RESET_ACTIVITY_REDUCER = 'RESET_ACTIVITY_REDUCER';
 export const SET_QUESTIONNAIRE_ANSWERS_LIST = 'SET_QUESTIONNAIRE_ANSWERS_LIST';
+export const INC_GOOD_ANSWERS_COUNT = 'INC_GOOD_ANSWERS_COUNT';
 
 export interface SetActivityType {
   type: typeof SET_ACTIVITY,
@@ -33,13 +34,17 @@ export interface SetQuestionnaireAnswersListType {
   type: typeof SET_QUESTIONNAIRE_ANSWERS_LIST,
   payload: Array<QuestionnaireAnswerType>,
 }
+export interface IncGoodAnswersCountType {
+  type: typeof INC_GOOD_ANSWERS_COUNT,
+}
 
 export type ActivityActionType =
 SetActivityType |
 SetCardIndexType |
 SetExitConfirmationModalType |
 AddQuestionnaireAnswerType |
-SetQuestionnaireAnswersListType;
+SetQuestionnaireAnswersListType |
+IncGoodAnswersCountType;
 
 export interface QuestionnaireAnswerType {
   _id?: string,

--- a/src/types/store/ActivityStoreType.ts
+++ b/src/types/store/ActivityStoreType.ts
@@ -52,4 +52,8 @@ export interface ActivityStateType {
   cardIndex: number | null,
   exitConfirmationModal: boolean,
   questionnaireAnswersList: Array<QuestionnaireAnswerType>,
+  score: {
+    goodAnswersCount: number,
+    quizCount: number,
+  }
 }

--- a/src/types/store/ActivityStoreType.ts
+++ b/src/types/store/ActivityStoreType.ts
@@ -57,8 +57,5 @@ export interface ActivityStateType {
   cardIndex: number | null,
   exitConfirmationModal: boolean,
   questionnaireAnswersList: Array<QuestionnaireAnswerType>,
-  score: {
-    goodAnswersCount: number,
-    quizCount: number,
-  }
+  score: number
 }

--- a/src/types/store/ActivityStoreType.ts
+++ b/src/types/store/ActivityStoreType.ts
@@ -43,8 +43,7 @@ SetActivityType |
 SetCardIndexType |
 SetExitConfirmationModalType |
 AddQuestionnaireAnswerType |
-SetQuestionnaireAnswersListType |
-IncGoodAnswersCountType;
+SetQuestionnaireAnswersListType;
 
 export interface QuestionnaireAnswerType {
   _id?: string,

--- a/src/types/store/ActivityStoreType.ts
+++ b/src/types/store/ActivityStoreType.ts
@@ -26,14 +26,16 @@ export interface AddQuestionnaireAnswerType {
   type: typeof ADD_QUESTIONNAIRE_ANSWER,
   payload: QuestionnaireAnswerType,
 }
-export interface ResetActivityReducer {
-  type: typeof RESET_ACTIVITY_REDUCER,
-}
 
 export interface SetQuestionnaireAnswersListType {
   type: typeof SET_QUESTIONNAIRE_ANSWERS_LIST,
   payload: Array<QuestionnaireAnswerType>,
 }
+
+export interface ResetActivityReducer {
+  type: typeof RESET_ACTIVITY_REDUCER,
+}
+
 export interface IncGoodAnswersCountType {
   type: typeof INC_GOOD_ANSWERS_COUNT,
 }
@@ -44,6 +46,8 @@ SetCardIndexType |
 SetExitConfirmationModalType |
 AddQuestionnaireAnswerType |
 SetQuestionnaireAnswersListType;
+
+export type ActivityActionWithoutPayloadType = ResetActivityReducer | IncGoodAnswersCountType;
 
 export interface QuestionnaireAnswerType {
   _id?: string,

--- a/src/types/store/StoreType.ts
+++ b/src/types/store/StoreType.ts
@@ -1,10 +1,10 @@
-import { ActivityStateType, ActivityActionType, ResetActivityReducer } from './ActivityStoreType';
+import { ActivityStateType, ActivityActionType, ActivityActionWithoutPayloadType } from './ActivityStoreType';
 import { MainStateType, MainActionType, ResetMainReducer } from './MainStoreType';
 
 export const LOG_OUT = 'log_out';
 export type ResetAllReducers = { type: typeof LOG_OUT };
 export type ActionType = ActivityActionType | MainActionType;
-export type ResetType = ResetActivityReducer | ResetMainReducer | ResetAllReducers;
+export type ActionWithoutPayloadType = ActivityActionWithoutPayloadType | ResetMainReducer | ResetAllReducers;
 
 export interface StateType {
   activities: ActivityStateType


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- Cas d'usage :  
ajout d'un champ (virtuel) lorsque l'on recupere une formation sur la page des etapes, pour savoir le nombre de quiz dans une activité
envoie du score a la fin d'une activité. 

Ce qui n'est pas inclus dans cette pr: 
- le design sur `CourseProfile` 
