### PR TITLE
COM-1521-gradient: fix gradient

### DIFF
--- a/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard/index.tsx
+++ b/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard/index.tsx
@@ -98,7 +98,7 @@ const MultipleChoiceQuestionCard = ({ card, cardIndex, incGoodAnswersCount }: Mu
       <ScrollView contentContainerStyle={style.container} showsVerticalScrollIndicator={false}>
         <Text style={cardsStyle.question}>{card.question}</Text>
         <View>
-          <Text style={style.informativeText}>Plusieurs réponses sont possibles</Text>
+          <Text style={cardsStyle.informativeText}>Plusieurs réponses sont possibles</Text>
           <FlatList data={answers} keyExtractor={(_, index) => index.toString()}
             renderItem={({ item, index }) => renderItem(item, index)} />
         </View>

--- a/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard/styles.ts
+++ b/src/screens/courses/cardTemplates/MultipleChoiceQuestionCard/styles.ts
@@ -1,6 +1,4 @@
 import { StyleSheet } from 'react-native';
-import { FIRA_SANS_REGULAR } from '../../../../styles/fonts';
-import { PINK } from '../../../../styles/colors';
 import { ABSOLUTE_BOTTOM_POSITION, INPUT_HEIGHT, MARGIN, PADDING } from '../../../../styles/metrics';
 
 const styles = (textColor: string, backgroundColor: string) => StyleSheet.create({
@@ -9,11 +7,6 @@ const styles = (textColor: string, backgroundColor: string) => StyleSheet.create
     flexGrow: 1,
     justifyContent: 'space-between',
     paddingBottom: PADDING.XL,
-  },
-  informativeText: {
-    ...FIRA_SANS_REGULAR.SM,
-    color: PINK[500],
-    marginBottom: MARGIN.SM,
   },
   explanation: {
     color: textColor,

--- a/src/screens/courses/cardTemplates/OrderTheSequenceCard/index.tsx
+++ b/src/screens/courses/cardTemplates/OrderTheSequenceCard/index.tsx
@@ -94,7 +94,14 @@ const OrderTheSequenceCard = ({ card, index, incGoodAnswersCount }: OrderTheSequ
         <DraggableFlatList
           contentContainerStyle={style.draggableContainer}
           ListHeaderComponentStyle={style.questionContainer}
-          ListHeaderComponent={<Text style={[cardsStyle.question, style.question]}>{card.question}</Text>}
+          ListHeaderComponent={
+            <>
+              <Text style={[cardsStyle.question, style.question]}>{card.question}</Text>
+              <Text style={style.informativeText}>
+                Classez les réponses dans le bon ordre : de la meilleure à la moins bonnes
+              </Text>
+            </>
+          }
           showsVerticalScrollIndicator={false} data={answers} keyExtractor={(_, answerIndex) => answerIndex.toString()}
           renderItem={renderItem} onDragEnd={setAnswersArray} />
       </View>

--- a/src/screens/courses/cardTemplates/OrderTheSequenceCard/index.tsx
+++ b/src/screens/courses/cardTemplates/OrderTheSequenceCard/index.tsx
@@ -97,8 +97,8 @@ const OrderTheSequenceCard = ({ card, index, incGoodAnswersCount }: OrderTheSequ
           ListHeaderComponent={
             <>
               <Text style={[cardsStyle.question, style.question]}>{card.question}</Text>
-              <Text style={style.informativeText}>
-                Classez les réponses dans le bon ordre : de la meilleure à la moins bonnes
+              <Text style={cardsStyle.informativeText}>
+                Classez les réponses dans le bon ordre : de la meilleure à la moins bonne
               </Text>
             </>
           }

--- a/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
+++ b/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
@@ -1,5 +1,4 @@
 import { StyleSheet } from 'react-native';
-import { PINK } from '../../../../styles/colors';
 import { FIRA_SANS_REGULAR } from '../../../../styles/fonts';
 import { ABSOLUTE_BOTTOM_POSITION, INPUT_HEIGHT, MARGIN, PADDING } from '../../../../styles/metrics';
 
@@ -18,11 +17,6 @@ const styles = (textColor: string, backgroundColor: string) => StyleSheet.create
   },
   question: {
     ...FIRA_SANS_REGULAR.MD,
-  },
-  informativeText: {
-    ...FIRA_SANS_REGULAR.SM,
-    color: PINK[500],
-    marginBottom: MARGIN.SM,
   },
   explanation: {
     color: textColor,

--- a/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
+++ b/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
@@ -6,11 +6,11 @@ const styles = (textColor: string, backgroundColor: string) => StyleSheet.create
   container: {
     marginHorizontal: MARGIN.LG,
     flexGrow: 1,
-    paddingBottom: PADDING.XL,
   },
   draggableContainer: {
     flexGrow: 1,
     justifyContent: 'space-between',
+    paddingBottom: PADDING.XL,
   },
   questionContainer: {
     flexGrow: 1,

--- a/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
+++ b/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native';
+import { PINK } from '../../../../styles/colors';
 import { FIRA_SANS_REGULAR } from '../../../../styles/fonts';
 import { ABSOLUTE_BOTTOM_POSITION, INPUT_HEIGHT, MARGIN, PADDING } from '../../../../styles/metrics';
 
@@ -17,6 +18,11 @@ const styles = (textColor: string, backgroundColor: string) => StyleSheet.create
   },
   question: {
     ...FIRA_SANS_REGULAR.MD,
+  },
+  informativeText: {
+    ...FIRA_SANS_REGULAR.SM,
+    color: PINK[500],
+    marginBottom: MARGIN.SM,
   },
   explanation: {
     color: textColor,

--- a/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
+++ b/src/screens/courses/cardTemplates/OrderTheSequenceCard/styles.ts
@@ -9,10 +9,10 @@ const styles = (textColor: string, backgroundColor: string) => StyleSheet.create
   },
   draggableContainer: {
     flexGrow: 1,
-    justifyContent: 'space-between',
     paddingBottom: PADDING.XL,
   },
   questionContainer: {
+    justifyContent: 'space-between',
     flexGrow: 1,
   },
   question: {

--- a/src/styles/cards.ts
+++ b/src/styles/cards.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { GREY } from './colors';
+import { GREY, PINK } from './colors';
 import { FIRA_SANS_REGULAR, FIRA_SANS_BLACK, FIRA_SANS_MEDIUM } from './fonts';
 import { BORDER_RADIUS, MARGIN, PADDING } from './metrics';
 
@@ -26,5 +26,10 @@ export default StyleSheet.create({
     textAlign: 'justify',
     paddingHorizontal: PADDING.XL,
     paddingVertical: PADDING.LG,
+  },
+  informativeText: {
+    ...FIRA_SANS_REGULAR.SM,
+    color: PINK[500],
+    marginBottom: MARGIN.SM,
   },
 });


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- Cas d'usage : 
retour de Romain, le gradient est quasiment invisible sur Mettre dans l'ordre, je l'ai déplacé dans draggableContainer qui est en fait le véritable container du composant (on garde container pour éviter un comportement pas souhaitable au drag (en gros la bull qu'on drag grossit et c'est moche donc on garde container pour y mettre le margin et empêcher ça))

mettre un texte explicatif au dessus du drag n drop