### PR TITLE
COM-1522-REFACTO: delete text progression

### DIFF
--- a/src/components/cards/ProgressBar/index.tsx
+++ b/src/components/cards/ProgressBar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
 import { connect } from 'react-redux';
 import { StateType } from '../../../types/store/StoreType';
 import Selectors from '../../../store/activities/selectors';
@@ -23,7 +23,6 @@ const ProgressBar = ({ maxProgress, progress }: ProgressBar) => {
       <View style={style.container}>
         <View style={style.content} />
       </View>
-      <Text style={style.text}>{progress}/{maxProgress}</Text>
     </>
   );
 };

--- a/src/components/cards/ProgressBar/styles.ts
+++ b/src/components/cards/ProgressBar/styles.ts
@@ -1,5 +1,4 @@
 import { StyleSheet } from 'react-native';
-import { FIRA_SANS_BOLD } from '../../../styles/fonts';
 import { GREY, YELLOW } from '../../../styles/colors';
 import { BORDER_RADIUS, BORDER_WIDTH, MARGIN, PROGRESS_BAR_HEIGHT } from '../../../styles/metrics';
 
@@ -21,10 +20,6 @@ const styles = (progressPercentage: number) => StyleSheet.create({
     width: `${progressPercentage}%`,
     borderRightWidth: BORDER_WIDTH,
     borderColor: GREY[100],
-  },
-  text: {
-    ...FIRA_SANS_BOLD.SM,
-    color: GREY[600],
   },
 });
 


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- Cas d'usage : 
Cas d'usage :
on retire le décompte des cartes (ex: 3/5) à côté de la progress bar