### PR TITLE
COM-1615-navigation: focus on catalog when leave explore and come back

### DIFF
--- a/src/screens/explore/About/index.tsx
+++ b/src/screens/explore/About/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { Image, Text, TouchableOpacity, View, ScrollView, ImageSourcePropType } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { connect } from 'react-redux';
-import { useIsFocused } from '@react-navigation/native';
+import { useIsFocused, CommonActions } from '@react-navigation/native';
 import get from 'lodash/get';
 import { navigate } from '../../../navigationRef';
 import { Context as AuthContext } from '../../../context/AuthContext';
@@ -18,7 +18,7 @@ import { ActionWithoutPayloadType } from '../../../types/store/StoreType';
 
 interface AboutProps {
   route: { params: { programId: string } },
-  navigation: { navigate: (path: string, activityId: any) => {} },
+  navigation: { navigate: (path: string, activityId: any) => {}, dispatch: (action: CommonActions.Action) => {}},
   loggedUserId: string,
   setIsCourse: (value: boolean) => void,
 }
@@ -75,6 +75,20 @@ const About = ({ route, navigation, loggedUserId, setIsCourse }: AboutProps) => 
     if (loggedUserId && isFocused) fetchData();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loggedUserId, isFocused]);
+
+  useEffect(() => {
+    if (!isFocused) {
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 0,
+          routes: [
+            { name: 'Catalog' },
+          ],
+        })
+      );
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isFocused]);
 
   const goBack = () => {
     navigate('Home', { screen: 'Explore', params: { screen: 'Catalog' } });

--- a/src/screens/explore/About/index.tsx
+++ b/src/screens/explore/About/index.tsx
@@ -77,16 +77,7 @@ const About = ({ route, navigation, loggedUserId, setIsCourse }: AboutProps) => 
   }, [loggedUserId, isFocused]);
 
   useEffect(() => {
-    if (!isFocused) {
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 0,
-          routes: [
-            { name: 'Catalog' },
-          ],
-        })
-      );
-    }
+    if (!isFocused) navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'Catalog' }] }));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFocused]);
 


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- Cas d'usage : quand on est sur "À propos" et qu'on quitte explore (en s'inscrivant/lançant une activité ou en switchant d'onglet) et qu'on revient dessus, on est focus sur le "Catalogue des formations e-learning" et non "À propos"
