### PR TITLE
Com 1615 navigation3

### DIFF
--- a/src/screens/explore/About/index.tsx
+++ b/src/screens/explore/About/index.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { Image, Text, TouchableOpacity, View, ScrollView, ImageSourcePropType } from 'react-native';
+import { Image, Text, TouchableOpacity, View, ScrollView, ImageSourcePropType, BackHandler } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { connect } from 'react-redux';
 import { CommonActions, useIsFocused } from '@react-navigation/native';
@@ -75,6 +75,13 @@ const About = ({ route, navigation, loggedUserId, setIsCourse }: AboutProps) => 
     if (loggedUserId && isFocused) fetchData();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loggedUserId, isFocused]);
+
+  const hardwareBackPress = () => {
+    goBack();
+    return true;
+  };
+
+  useEffect(() => { BackHandler.addEventListener('hardwareBackPress', hardwareBackPress); });
 
   const goBack = () => {
     navigate('Home', { screen: 'Explore', params: { screen: 'Catalog' } });

--- a/src/screens/explore/About/index.tsx
+++ b/src/screens/explore/About/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { Image, Text, TouchableOpacity, View, ScrollView, ImageSourcePropType, BackHandler } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { connect } from 'react-redux';
-import { CommonActions, useIsFocused } from '@react-navigation/native';
+import { CommonActions, StackActions, StackActionType, useIsFocused } from '@react-navigation/native';
 import get from 'lodash/get';
 import { navigate } from '../../../navigationRef';
 import { Context as AuthContext } from '../../../context/AuthContext';
@@ -18,7 +18,9 @@ import { ActionWithoutPayloadType } from '../../../types/store/StoreType';
 
 interface AboutProps {
   route: { params: { programId: string } },
-  navigation: { navigate: (path: string, activityId: any) => {}, dispatch: (action: CommonActions.Action) => {}},
+  navigation: {
+    navigate: (path: string, activityId: any) => {},
+    dispatch: (action: CommonActions.Action | StackActionType) => {}},
   loggedUserId: string,
   setIsCourse: (value: boolean) => void,
 }
@@ -93,17 +95,19 @@ const About = ({ route, navigation, loggedUserId, setIsCourse }: AboutProps) => 
   );
 
   const goToNextActivity = () => {
-    navigation.navigate('Home', { screen: 'Courses', params: { screen: 'CourseProfile', params: { courseId } } });
+    navigation.dispatch(StackActions.push('CourseProfile', { courseId }));
     navigation.navigate('CardContainer', { activityId: nextActivityId, courseId });
   };
+
+  const resetExploreStack = () => navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'Catalog' }] }));
 
   const subscribeAndGoToCourseProfile = async () => {
     try {
       if (!hasAlreadySubscribed) await Courses.registerToELearningCourse(courseId);
       setIsCourse(true);
-      if (nextActivityId) await goToNextActivity();
-      else await goToCourse();
-      navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'Catalog' }] }));
+      if (nextActivityId) goToNextActivity();
+      else goToCourse();
+      setTimeout(resetExploreStack, 100);
     } catch (e) {
       if (e.status === 401) signOut();
     }

--- a/src/screens/explore/About/index.tsx
+++ b/src/screens/explore/About/index.tsx
@@ -92,14 +92,17 @@ const About = ({ route, navigation, loggedUserId, setIsCourse }: AboutProps) => 
     { screen: 'Courses', params: { screen: 'CourseProfile', params: { courseId } } }
   );
 
-  const goToNextActivity = () => navigation.navigate('CardContainer', { activityId: nextActivityId, courseId });
+  const goToNextActivity = () => {
+    navigation.navigate('Home', { screen: 'Courses', params: { screen: 'CourseProfile', params: { courseId } } });
+    navigation.navigate('CardContainer', { activityId: nextActivityId, courseId });
+  };
 
   const subscribeAndGoToCourseProfile = async () => {
     try {
       if (!hasAlreadySubscribed) await Courses.registerToELearningCourse(courseId);
       setIsCourse(true);
-      if (nextActivityId) goToNextActivity();
-      else goToCourse();
+      if (nextActivityId) await goToNextActivity();
+      else await goToCourse();
       navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'Catalog' }] }));
     } catch (e) {
       if (e.status === 401) signOut();


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- Cas d'usage : 
quand je lance une activité depuis à propos ou que je la quitte* je n'ai pas de "flash" furtifs des screens intermédiaires

(à vérifier que ça marche quand on s'inscrit à une formation et pas seulement quand on en continue une)

*quitter = flèche retour sur la startcard, crois sur les autres cartes, finir l'activité ou flèche back native sur android)