### PR TITLE
COM-1687 fix <trou> displaying instead of gap

### DIFF
--- a/src/components/cards/FillTheGapQuestion/index.tsx
+++ b/src/components/cards/FillTheGapQuestion/index.tsx
@@ -10,6 +10,7 @@ interface FillTheGapQuestionProps {
 }
 
 const FillTheGapQuestion = ({ text, isValidated, renderGap }: FillTheGapQuestionProps) => {
+  // DON'T remove the spaces around '<trou>' in replace. They are needed for the display.
   const splittedText = text.replace(/<trou>[^<]*<\/trou>/g, ' <trou> ').split(/\s+/);
 
   const formatText = (words) => {
@@ -20,7 +21,7 @@ const FillTheGapQuestion = ({ text, isValidated, renderGap }: FillTheGapQuestion
         i += 1;
         return gapIndex;
       }
-      if (words[idx - 1] === '<trou>') return `${word}`;
+      if (words[idx - 1] === '<trou>') return word;
       return word;
     });
   };

--- a/src/components/cards/FillTheGapQuestion/index.tsx
+++ b/src/components/cards/FillTheGapQuestion/index.tsx
@@ -10,7 +10,7 @@ interface FillTheGapQuestionProps {
 }
 
 const FillTheGapQuestion = ({ text, isValidated, renderGap }: FillTheGapQuestionProps) => {
-  const splittedText = text.replace(/<trou>[^<]*<\/trou>/g, '<trou>').split(' ');
+  const splittedText = text.replace(/<trou>[^<]*<\/trou>/g, ' <trou> ').split(/\s+/);
 
   const formatText = (words) => {
     let i = 0;
@@ -20,7 +20,7 @@ const FillTheGapQuestion = ({ text, isValidated, renderGap }: FillTheGapQuestion
         i += 1;
         return gapIndex;
       }
-      if (words[idx - 1] === '<trou>') return ` ${word}`;
+      if (words[idx - 1] === '<trou>') return `${word}`;
       return word;
     });
   };

--- a/src/components/cards/FillTheGapQuestion/index.tsx
+++ b/src/components/cards/FillTheGapQuestion/index.tsx
@@ -15,13 +15,13 @@ const FillTheGapQuestion = ({ text, isValidated, renderGap }: FillTheGapQuestion
 
   const formatText = (words) => {
     let i = 0;
-    return words.map((word, idx) => {
+    return words.map((word) => {
       if (word === '<trou>') {
         const gapIndex = `<trou${i}>`;
         i += 1;
         return gapIndex;
       }
-      if (words[idx - 1] === '<trou>') return word;
+
       return word;
     });
   };


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- Cas d'usage : 
Si les mots sont collés aux balises <trou> dans le texte a trou, on voit un gap et non pas <trou>
Pour tester vous pouvez regarder communication empathique/reporter un echange/ professionnel du prendre soin. 