### PR TITLE
COM-1653: desactiver modification quand retour du back en attente

### DIFF
--- a/src/components/CreateAccountForm/index.tsx
+++ b/src/components/CreateAccountForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Text, View, BackHandler, KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
 import NiInput from '../../components/form/Input';
 import NiButton from '../../components/form/Button';
@@ -19,13 +19,21 @@ interface CreateAccountProps {
 }
 const CreateAccountForm = ({ navigation, index, data, isLoading, setData, goBack, create }: CreateAccountProps) => {
   const isIOS = Platform.OS === 'ios';
+  const isDisabledBackHandler = useRef(isLoading);
 
   const hardwareBackPress = () => {
-    goBack(index);
+    if (!isDisabledBackHandler.current) goBack(index);
     return true;
   };
 
-  useEffect(() => { BackHandler.addEventListener('hardwareBackPress', hardwareBackPress); });
+  useEffect(() => {
+    BackHandler.addEventListener('hardwareBackPress', hardwareBackPress);
+
+    return () => { BackHandler.removeEventListener('hardwareBackPress', hardwareBackPress); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => { isDisabledBackHandler.current = isLoading; }, [isLoading]);
 
   const onChangeText = (text, fieldToChangeIndex) => {
     setData(

--- a/src/components/CreateAccountForm/index.tsx
+++ b/src/components/CreateAccountForm/index.tsx
@@ -90,7 +90,7 @@ const CreateAccountForm = ({ navigation, index, data, isLoading, setData, goBack
         <Text style={styles.title}>{data[0].title}</Text>
         {data.map((d, i) => <View style={styles.input} key={`container${i}`}>
           <NiInput key={`content${i}`} caption={d.caption} value={d.value} type={d.type}
-            darkMode={false} onChangeText={text => onChangeText(text, i)} editable={!isLoading}
+            darkMode={false} onChangeText={text => onChangeText(text, i)} disabled={isLoading}
             validationMessage={!d.isValid && d.isValidationAttempted ? d.errorMessage : ''} required={d.required} />
         </View>)}
         <View style={styles.footer}>

--- a/src/components/CreateAccountForm/index.tsx
+++ b/src/components/CreateAccountForm/index.tsx
@@ -82,7 +82,7 @@ const CreateAccountForm = ({ navigation, index, data, isLoading, setData, goBack
         <Text style={styles.title}>{data[0].title}</Text>
         {data.map((d, i) => <View style={styles.input} key={`container${i}`}>
           <NiInput key={`content${i}`} caption={d.caption} value={d.value} type={d.type}
-            darkMode={false} onChangeText={text => onChangeText(text, i)}
+            darkMode={false} onChangeText={text => onChangeText(text, i)} editable={!isLoading}
             validationMessage={!d.isValid && d.isValidationAttempted ? d.errorMessage : ''} required={d.required} />
         </View>)}
         <View style={styles.footer}>

--- a/src/components/form/Input/index.tsx
+++ b/src/components/form/Input/index.tsx
@@ -14,6 +14,7 @@ interface InputProps {
   darkMode?: boolean,
   validationMessage?: string,
   required?: boolean,
+  editable?: boolean,
   isKeyboardOpen?: (value: boolean) => void,
 }
 
@@ -25,6 +26,7 @@ const Input = ({
   darkMode,
   validationMessage = '',
   required = false,
+  editable = true,
   isKeyboardOpen,
 }: InputProps) => {
   const [showPassword, setShowPassword] = useState(false);
@@ -67,7 +69,7 @@ const Input = ({
           <TextInput value={value} onChangeText={onChangeText} onTouchStart={() => setIsSelected(true)}
             onBlur={() => setIsSelected(false)} testID={caption} secureTextEntry={secureTextEntry}
             style={style.innerInput} autoCapitalize={autoCapitalize} keyboardType={keyboradType}
-            textContentType='oneTimeCode' />
+            textContentType='oneTimeCode' editable={editable} />
           {isPassword &&
           <TouchableOpacity style={style.inputIcon} onPress={togglePassword}>
             <Feather name={showPasswordIcon} size={ICON.XS} />

--- a/src/components/form/Input/index.tsx
+++ b/src/components/form/Input/index.tsx
@@ -14,7 +14,7 @@ interface InputProps {
   darkMode?: boolean,
   validationMessage?: string,
   required?: boolean,
-  editable?: boolean,
+  disabled?: boolean,
   isKeyboardOpen?: (value: boolean) => void,
 }
 
@@ -26,7 +26,7 @@ const Input = ({
   darkMode,
   validationMessage = '',
   required = false,
-  editable = true,
+  disabled = false,
   isKeyboardOpen,
 }: InputProps) => {
   const [showPassword, setShowPassword] = useState(false);
@@ -69,7 +69,7 @@ const Input = ({
           <TextInput value={value} onChangeText={onChangeText} onTouchStart={() => setIsSelected(true)}
             onBlur={() => setIsSelected(false)} testID={caption} secureTextEntry={secureTextEntry}
             style={style.innerInput} autoCapitalize={autoCapitalize} keyboardType={keyboradType}
-            textContentType='oneTimeCode' editable={editable} />
+            textContentType='oneTimeCode' editable={!disabled} />
           {isPassword &&
           <TouchableOpacity style={style.inputIcon} onPress={togglePassword}>
             <Feather name={showPasswordIcon} size={ICON.XS} />

--- a/src/screens/CreateAccount/index.tsx
+++ b/src/screens/CreateAccount/index.tsx
@@ -121,7 +121,8 @@ const CreateAccount = ({ route, navigation }: CreateAccountProps) => {
       {() => (
         <>
           <View style={styles.header}>
-            <IconButton name='arrow-left' onPress={() => goBack(i)} size={ICON.MD} color={GREY[600]} />
+            <IconButton name='arrow-left' onPress={() => goBack(i)} size={ICON.MD} color={GREY[600]}
+              disabled={isLoading} />
             <ProgressBar progress={((i + 1) / formList.length) * 100} />
           </View>
           <CreateAccountForm navigation={navigation} isLoading={isLoading} data={fields} setData={setForm} index={i}

--- a/src/screens/EmailForm/index.tsx
+++ b/src/screens/EmailForm/index.tsx
@@ -26,7 +26,7 @@ const EmailForm = ({ route, navigation }: EmailFormProps) => {
   const [isValid, setIsValid] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const isDisabledBackHandler = useRef(isLoading);
-  const [isTouch, setIsTouch] = useState<boolean>(false);
+  const [isValidationAttempted, setIsValidationAttempted] = useState<boolean>(false);
   const [isBottomPopUpVisible, setIsBottomPopUpVisible] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [error, setError] = useState(false);
@@ -66,6 +66,7 @@ const EmailForm = ({ route, navigation }: EmailFormProps) => {
 
   const saveEmail = async () => {
     try {
+      setIsValidationAttempted(true);
       setIsLoading(true);
       if (isValid) {
         if (error) setError(false);
@@ -92,7 +93,6 @@ const EmailForm = ({ route, navigation }: EmailFormProps) => {
   const enterEmail = (text) => {
     setErrorMessage('');
     setEmail(text);
-    setIsTouch(true);
   };
 
   const confirm = () => {
@@ -101,7 +101,7 @@ const EmailForm = ({ route, navigation }: EmailFormProps) => {
   };
 
   const validationMessage = () => {
-    if (unvalidEmail && isTouch) return 'Ton adresse e-mail n\'est pas valide';
+    if (unvalidEmail && isValidationAttempted) return 'Ton adresse e-mail n\'est pas valide';
     if (error) return errorMessage;
     return '';
   };
@@ -127,8 +127,8 @@ const EmailForm = ({ route, navigation }: EmailFormProps) => {
             onChangeText={text => enterEmail(text)} isKeyboardOpen={setIsKeyboardOpen} editable={!isLoading} />
         </View>
         <View style={style.footer}>
-          <NiButton caption="Valider" onPress={saveEmail} disabled={!isValid} loading={isLoading}
-            bgColor={isValid ? PINK[500] : GREY[500]} color={WHITE} borderColor={isValid ? PINK[500] : GREY[500]} />
+          <NiButton caption="Valider" onPress={saveEmail} loading={isLoading} bgColor={PINK[500]}
+            color={WHITE} borderColor={PINK[500]} />
         </View>
         <BottomPopUp onPressConfirmButton={confirm} visible={isBottomPopUpVisible}
           title='Vérifie tes e-mails !' contentText={renderContentText} />

--- a/src/screens/EmailForm/index.tsx
+++ b/src/screens/EmailForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { Text, View, KeyboardAvoidingView, Platform, BackHandler } from 'react-native';
 import ExitModal from '../../components/ExitModal';
 import IconButton from '../../components/IconButton';
@@ -25,6 +25,7 @@ const EmailForm = ({ route, navigation }: EmailFormProps) => {
   const [unvalidEmail, setUnvalidEmail] = useState<boolean>(false);
   const [isValid, setIsValid] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const isDisabledBackHandler = useRef(isLoading);
   const [isTouch, setIsTouch] = useState<boolean>(false);
   const [isBottomPopUpVisible, setIsBottomPopUpVisible] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState('');
@@ -33,11 +34,18 @@ const EmailForm = ({ route, navigation }: EmailFormProps) => {
   const style = styles(isKeyboardOpen && !IS_LARGE_SCREEN);
 
   const hardwareBackPress = () => {
-    setExitConfirmationModal(true);
+    if (!isDisabledBackHandler.current) setExitConfirmationModal(true);
     return true;
   };
 
-  useEffect(() => { BackHandler.addEventListener('hardwareBackPress', hardwareBackPress); });
+  useEffect(() => {
+    BackHandler.addEventListener('hardwareBackPress', hardwareBackPress);
+
+    return () => { BackHandler.removeEventListener('hardwareBackPress', hardwareBackPress); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => { isDisabledBackHandler.current = isLoading; }, [isLoading]);
 
   useEffect(() => { setUnvalidEmail(!email.match(EMAIL_REGEX)); }, [email]);
 

--- a/src/screens/EmailForm/index.tsx
+++ b/src/screens/EmailForm/index.tsx
@@ -124,7 +124,7 @@ const EmailForm = ({ route, navigation }: EmailFormProps) => {
         <Text style={style.title}>Quelle est ton adresse mail ?</Text>
         <View style={style.input}>
           <NiInput caption="E-mail" value={email} type="email" validationMessage={validationMessage()} darkMode={false}
-            onChangeText={text => enterEmail(text)} isKeyboardOpen={setIsKeyboardOpen} editable={!isLoading} />
+            onChangeText={text => enterEmail(text)} isKeyboardOpen={setIsKeyboardOpen} disabled={isLoading} />
         </View>
         <View style={style.footer}>
           <NiButton caption="Valider" onPress={saveEmail} loading={isLoading} bgColor={PINK[500]}

--- a/src/screens/EmailForm/index.tsx
+++ b/src/screens/EmailForm/index.tsx
@@ -106,7 +106,8 @@ const EmailForm = ({ route, navigation }: EmailFormProps) => {
     <KeyboardAvoidingView behavior={isIOS ? 'padding' : 'height'} style={style.keyboardAvoidingView}
       keyboardVerticalOffset={IS_LARGE_SCREEN ? MARGIN.MD : MARGIN.XS} >
       <View style={style.goBack}>
-        <IconButton name='x-circle' onPress={() => setExitConfirmationModal(true)} size={ICON.MD} color={GREY[600]} />
+        <IconButton name='x-circle' onPress={() => setExitConfirmationModal(true)} size={ICON.MD} color={GREY[600]}
+          disabled={isLoading} />
         <ExitModal onPressConfirmButton={goBack} visible={exitConfirmationModal}
           onPressCancelButton={() => setExitConfirmationModal(false)}
           title={'Es-tu sûr de cela ?'} contentText={'Tu reviendras à la page d\'accueil.'} />
@@ -115,7 +116,7 @@ const EmailForm = ({ route, navigation }: EmailFormProps) => {
         <Text style={style.title}>Quelle est ton adresse mail ?</Text>
         <View style={style.input}>
           <NiInput caption="E-mail" value={email} type="email" validationMessage={validationMessage()} darkMode={false}
-            onChangeText={text => enterEmail(text)} isKeyboardOpen={setIsKeyboardOpen} />
+            onChangeText={text => enterEmail(text)} isKeyboardOpen={setIsKeyboardOpen} editable={!isLoading} />
         </View>
         <View style={style.footer}>
           <NiButton caption="Valider" onPress={saveEmail} disabled={!isValid} loading={isLoading}


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- Cas d'usage : 
désactivation des inputs (textinput, bouton de retour arrière / bouton croix et backhandler quand on attend un retour du back)
prise en compte du commentaire de Romain sur le ticket COM-1701 : "sur la page EmailForm ne pas mettre le bouton en inactif et gris. Il faut que ce bouton soit actif, et quand l’utilisateur clique dessus alors que le champ renseigné ne respecte pas les contraintes, le message d’erreur apparaît (comme c’est le cas dans le process de création de compte, pour le Nom par exemple)"