### PR TITLE
COM-1777 - update message to access camera

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "slug": "compani",
     "description": "Nous aidons les intervenants, les managers du secteur et les dirigeants à pratiquer un accompagnement humain",
     "platforms": ["ios", "android"],
-    "version": "1.0.0",
+    "version": "1.1.0",
     "orientation": "portrait",
     "primaryColor": "#FFFFFF",
     "icon": "./assets/images/android_icon.png",
@@ -20,14 +20,17 @@
     "assetBundlePatterns": ["assets/images/*"],
     "ios": {
       "bundleIdentifier": "com.alenvi.compani",
-      "buildNumber": "1.0.14",
+      "buildNumber": "1.0.18",
       "requireFullScreen": true,
-      "icon": "./assets/images/ios_icon.png"
+      "icon": "./assets/images/ios_icon.png",
+      "infoPlist": {
+        "NSCameraUsageDescription": "Allow access to your camera so you can take a picture and upload it as your profile picture to Compani"
+      }
     },
     "android": {
       "package": "com.alenvi.compani",
       "permissions": [],
-      "versionCode": 36,
+      "versionCode": 42,
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/android_icon.png"
       }


### PR DESCRIPTION
- [ ] J'ai testé sur iphone - je n'ai pas reussi a tester, car j'ai deja accepté ><
- [ ] J'ai testé sur android - np 

- Cas d'usage : 
j'ai recu ce message d'apple

```
Guideline 5.1.1 - Legal - Privacy - Data Collection and Storage


We noticed that your app requests the user’s consent to access the camera, but doesn’t sufficiently explain the use of the camera in the purpose string.

To help users make informed decisions about how their data is used, all permission request alerts need to specify how your app will use the requested information.

Next Steps

Please revise the relevant purpose string in your app’s Info.plist file to specify why your app needs access to the user’s camera. Make sure the purpose string includes an example of how the user’s data will be used.

You can modify your app's Info.plist file using the property list editor in Xcode.

Resources

- See examples of helpful, informative purpose strings. : https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/requesting-permission/
- Review a list of relevant property list keys. https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW18

We look forward to reviewing your resubmitted app.
```


j;ai suivi ces deux liens : 
- https://docs.expo.io/distribution/app-stores/?redirected#system-permissions-dialogs-on-ios
- https://docs.expo.io/versions/latest/config/app/#infoplist