### PR TITLE
add permission for camera

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,8 +30,8 @@
     },
     "android": {
       "package": "com.alenvi.compani",
-      "permissions": [],
-      "versionCode": 43,
+      "permissions": ["CAMERA", "MEDIA_LIBRARY"],
+      "versionCode": 45,
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/android_icon.png"
       }


### PR DESCRIPTION
- [ ] J'ai testé sur iphone -np
- [ ] J'ai testé sur android -np

- Cas d'usage : Pour le store android, il faut ajouter les permissions dont on a besoin: ici camera et media library. 
https://docs.expo.io/distribution/app-stores/#android-permissions
https://docs.expo.io/versions/latest/sdk/camera/#configuration
https://docs.expo.io/versions/latest/sdk/imagepicker/#configuration
