### PR TITLE
COM-1764: remove absolute position

### DIFF
--- a/src/components/cards/QuizCardFooter/index.tsx
+++ b/src/components/cards/QuizCardFooter/index.tsx
@@ -5,7 +5,7 @@ import cardsStyle from '../../../styles/cards';
 import styles from './styles';
 import { GREY } from '../../../styles/colors';
 
-interface QuestionCardFooterProps {
+interface QuizCardFooterProps {
   isValidated: boolean,
   isValid: boolean,
   cardIndex: number,
@@ -23,7 +23,7 @@ const QuizCardFooter = ({
   explanation,
   buttonDisabled = false,
   onPressFooterButton,
-}: QuestionCardFooterProps) => {
+}: QuizCardFooterProps) => {
   const style = styles(footerColors.text, footerColors.background);
   return (
     <>

--- a/src/styles/cards.ts
+++ b/src/styles/cards.ts
@@ -1,7 +1,7 @@
 import { StyleSheet } from 'react-native';
 import { GREY, PINK } from './colors';
 import { FIRA_SANS_REGULAR, FIRA_SANS_BLACK, FIRA_SANS_MEDIUM } from './fonts';
-import { ABSOLUTE_BOTTOM_POSITION, BORDER_RADIUS, INPUT_HEIGHT, MARGIN, PADDING } from './metrics';
+import { BORDER_RADIUS, INPUT_HEIGHT, MARGIN, PADDING } from './metrics';
 
 export default StyleSheet.create({
   title: {
@@ -23,10 +23,6 @@ export default StyleSheet.create({
   },
   explanation: {
     minHeight: INPUT_HEIGHT,
-    position: 'absolute',
-    right: 0,
-    left: 0,
-    bottom: ABSOLUTE_BOTTOM_POSITION,
     paddingHorizontal: PADDING.XL,
     paddingVertical: PADDING.LG,
   },


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- Cas d'usage : 
retirer la position absolue de l’explanation dans QuizCardFooter pour qu'elle ne cache pas les réponses au quizz