### PR TITLE
COM-1820 - fix link to update on ios

### DIFF
--- a/src/components/UpdateAppModal/index.tsx
+++ b/src/components/UpdateAppModal/index.tsx
@@ -10,7 +10,7 @@ interface UpdateAppModalProps {
 
 const UpdateAppModal = ({ visible }: UpdateAppModalProps) => {
   const appUrl = Platform.OS === 'ios'
-    ? 'https://apps.apple.com/app/id1447513534'
+    ? 'https://apps.apple.com/app/id/1516691161'
     : 'market://details?id=com.alenvi.compani';
 
   return (


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [ ] J'ai testé sur android - np pertinent pour ce changement qui ne concerne que ios - sur android le lien est le bon

- Cas d'usage : Sur iphone, quand on me demande de mettre l'application a jour, je suis redirigée vers la bonne app dans l'app store
