### PR TITLE
Com 1815 2

### DIFF
--- a/src/components/ForgotPasswordModal/index.tsx
+++ b/src/components/ForgotPasswordModal/index.tsx
@@ -11,11 +11,12 @@ import { GREY, PINK, WHITE } from '../../styles/colors';
 import styles from './styles';
 
 interface ForgotPasswordModalProps {
+  visible: boolean,
   email: string,
-  onRequestClose: () => void,
+  setForgotPasswordModal: (value: boolean) => void,
 }
 
-const ForgotPasswordModal = ({ email, onRequestClose }: ForgotPasswordModalProps) => {
+const ForgotPasswordModal = ({ visible, email, setForgotPasswordModal }: ForgotPasswordModalProps) => {
   const [code, setCode] = useState<Array<string>>(['', '', '', '']);
   const [isKeyboardOpen, setIsKeyboardOpen] = useState<boolean>(false);
   const [isValidationAttempted, setIsValidationAttempted] = useState<boolean>(false);
@@ -77,12 +78,23 @@ const ForgotPasswordModal = ({ email, onRequestClose }: ForgotPasswordModalProps
     if (!invalidCode) sendCode(formattedCode);
   };
 
+  const onRequestClose = () => {
+    setCode(['', '', '', '']);
+    setIsKeyboardOpen(false);
+    setIsValidationAttempted(false);
+    setInvalidCode(false);
+    setErrorMessage('');
+    setCodeRecipient('');
+    setChosenMethod('');
+    setForgotPasswordModal(false);
+  };
+
   const sendCode = async (formattedCode) => {
     try {
       setIsLoading(true);
+      onRequestClose();
       const checkToken = await Authentication.passwordToken(email, formattedCode);
       navigation.navigate('PasswordReset', { userId: checkToken.user._id, email, token: checkToken.token });
-      onRequestClose();
     } catch (e) {
       setInvalidCode(true);
       setErrorMessage('Oops, le code n\'est pas valide');
@@ -166,10 +178,10 @@ const ForgotPasswordModal = ({ email, onRequestClose }: ForgotPasswordModalProps
   );
 
   return (
-    <Modal transparent={true} onRequestClose={onRequestClose}>
+    <Modal visible={visible} transparent={true} onRequestClose={onRequestClose}>
       <ScrollView contentContainerStyle={styles.modalContainer} keyboardShouldPersistTaps='handled'>
         <View style={styles.modalContent}>
-          <FeatherButton name={'x-circle'} onPress={onRequestClose} size={ICON.LG} color={GREY[600]}
+          <FeatherButton name='x-circle' onPress={onRequestClose} size={ICON.LG} color={GREY[600]}
             style={styles.goBack} />
           <Text style={styles.title}>Confirmez votre identité</Text>
           {!codeRecipient ? beforeCodeSent() : afterCodeSent()}

--- a/src/components/ForgotPasswordModal/index.tsx
+++ b/src/components/ForgotPasswordModal/index.tsx
@@ -46,8 +46,10 @@ const ForgotPasswordModal = ({ visible, email, setForgotPasswordModal }: ForgotP
   });
 
   useEffect(() => {
-    setInvalidCode(!(code.every(char => char !== '' && Number.isInteger(Number(char)))));
-    if (isValidationAttempted) setErrorMessage('Le format du code est incorrect');
+    const isCodeInvalid = !(code.every(char => char !== '' && Number.isInteger(Number(char))));
+    setInvalidCode(isCodeInvalid);
+    if (isCodeInvalid && isValidationAttempted) setErrorMessage('Le format du code est incorrect');
+    else setErrorMessage('');
   }, [code, isValidationAttempted]);
 
   const onChangeText = (char, index) => {

--- a/src/components/ForgotPasswordModal/index.tsx
+++ b/src/components/ForgotPasswordModal/index.tsx
@@ -33,17 +33,15 @@ const ForgotPasswordModal = ({ visible, email, setForgotPasswordModal }: ForgotP
   const [codeRecipient, setCodeRecipient] = useState<string>('');
   const [chosenMethod, setChosenMethod] = useState<string>('');
 
-  useEffect(() => {
-    Keyboard.addListener('keyboardDidHide', () => setIsKeyboardOpen(false));
-    return () => {
-      Keyboard.removeListener('keyboardDidHide', () => setIsKeyboardOpen(false));
-    };
-  });
+  const keyboardDidHide = () => setIsKeyboardOpen(false);
+  const keyboardDidShow = () => setIsKeyboardOpen(true);
 
   useEffect(() => {
-    Keyboard.addListener('keyboardDidShow', () => setIsKeyboardOpen(true));
+    Keyboard.addListener('keyboardDidHide', keyboardDidHide);
+    Keyboard.addListener('keyboardDidShow', keyboardDidShow);
     return () => {
-      Keyboard.removeListener('keyboardDidShow', () => setIsKeyboardOpen(true));
+      Keyboard.removeListener('keyboardDidHide', keyboardDidHide);
+      Keyboard.removeListener('keyboardDidShow', keyboardDidShow);
     };
   });
 
@@ -92,8 +90,8 @@ const ForgotPasswordModal = ({ visible, email, setForgotPasswordModal }: ForgotP
   const sendCode = async (formattedCode) => {
     try {
       setIsLoading(true);
-      onRequestClose();
       const checkToken = await Authentication.passwordToken(email, formattedCode);
+      onRequestClose();
       navigation.navigate('PasswordReset', { userId: checkToken.user._id, email, token: checkToken.token });
     } catch (e) {
       setInvalidCode(true);

--- a/src/screens/EmailForm/index.tsx
+++ b/src/screens/EmailForm/index.tsx
@@ -107,8 +107,8 @@ const EmailForm = ({ route, navigation }: EmailFormProps) => {
           <NiButton caption="Valider" onPress={saveEmail} loading={isLoading} bgColor={PINK[500]}
             color={WHITE} borderColor={PINK[500]} />
         </View>
-        {forgotPasswordModal &&
-          <ForgotPasswordModal email={email} onRequestClose={() => setForgotPasswordModal(false)} />}
+        <ForgotPasswordModal email={email} setForgotPasswordModal={setForgotPasswordModal}
+          visible={forgotPasswordModal} />
       </View>
     </KeyboardAvoidingView>
   );


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- Cas d'usage : plus de warning d'erreur quand on quitte la modale forgot password (erreur visiblement dû au listener sur les input texte avec Keyboard.addListener. Il semble que l'erreur popait car on n'appelait pas la une même fonction au mount et au unmount mais un set State et il vaut mieux utiliser cela sous forme de fonction unique qu'on monte et démonte)
+ petit changement dans la logique du setErrormessage

(fait en PP avec Chloé, donc pas besoin qu'elle relise, tu pourras merger directement après validation @sophiemoustard)
