### PR TITLE
Com 1863

### DIFF
--- a/src/components/cards/OrderProposition/index.tsx
+++ b/src/components/cards/OrderProposition/index.tsx
@@ -32,7 +32,7 @@ const OrderProposition = ({ item, isValidated = false, drag }: OrderPropositionP
 
   return (
     <View style={style.container}>
-      <TouchableOpacity style={style.contentContainer} disabled={isValidated} onLongPress={drag} >
+      <TouchableOpacity style={style.contentContainer} disabled={isValidated} onLongPress={drag} delayLongPress={100}>
         <View style= {style.indexContainer}>
           <View style={style.index}>
             <Text style={style.indexText}>{item.tempPosition + 1}</Text>

--- a/src/components/cards/OrderProposition/index.tsx
+++ b/src/components/cards/OrderProposition/index.tsx
@@ -32,20 +32,21 @@ const OrderProposition = ({ item, isValidated = false, drag }: OrderPropositionP
 
   return (
     <View style={style.container}>
-      <TouchableOpacity style={style.contentContainer} disabled={isValidated} onLongPress={drag} delayLongPress={100}>
-        <TouchableOpacity style= {style.indexContainer} onLongPress={drag} delayLongPress={0}>
+      <View style={style.contentContainer}>
+        <TouchableOpacity style= {style.indexContainer} disabled={isValidated} onLongPress={drag} delayLongPress={0}
+          activeOpacity={1}>
           <View style={style.index}>
             <Text style={style.indexText}>{item.tempPosition + 1}</Text>
           </View>
           <Shadow customStyle={style.indexShadow} />
         </TouchableOpacity>
-        <View style={style.answerContainer}>
+        <TouchableOpacity style={style.answerContainer} disabled={isValidated} onLongPress={drag} delayLongPress={100}>
           <View style={style.answer}>
             <Text style={style.answerText}>{item.label}</Text>
           </View>
           <Shadow customStyle={style.answerShadow} />
-        </View>
-      </TouchableOpacity>
+        </TouchableOpacity>
+      </View>
     </View>
   );
 };

--- a/src/components/cards/OrderProposition/index.tsx
+++ b/src/components/cards/OrderProposition/index.tsx
@@ -33,12 +33,12 @@ const OrderProposition = ({ item, isValidated = false, drag }: OrderPropositionP
   return (
     <View style={style.container}>
       <TouchableOpacity style={style.contentContainer} disabled={isValidated} onLongPress={drag} delayLongPress={100}>
-        <View style= {style.indexContainer}>
+        <TouchableOpacity style= {style.indexContainer} onLongPress={drag} delayLongPress={0}>
           <View style={style.index}>
             <Text style={style.indexText}>{item.tempPosition + 1}</Text>
           </View>
           <Shadow customStyle={style.indexShadow} />
-        </View>
+        </TouchableOpacity>
         <View style={style.answerContainer}>
           <View style={style.answer}>
             <Text style={style.answerText}>{item.label}</Text>


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- Cas d'usage : 
Modification du drag & drop sur les cartes OrderTheSequence.
Changements :
- drag & drop s'active plus rapidement
- drag & drop instantané sur le numéro

_Amélioration possible :_
- Rendre la réponse sélectionnée plus visible -> semble complexe à mettre en place car l'index donné par onDragBegin fluctue (lorsque le drag débute il renvois l'index de la réponse sélectionné puis repasse à null). On ne peut donc pas se baser sur lui pour gérer l'affichage. Une autre solution (qui était celle qui semblait fonctionner, était de passer par la props tempPosition. Cependant celle ci change lorsque l'ordre de la liste change, ce qui la rend obsolète.
