### PR TITLE
COM-1957 : show draft program section for testers

### DIFF
--- a/src/screens/courses/CourseList/index.tsx
+++ b/src/screens/courses/CourseList/index.tsx
@@ -70,8 +70,8 @@ const CourseList = ({ setIsCourse, navigation, loggedUserId }: CourseListProps) 
     } catch (e) {
       if (e.status === 401) signOut();
       console.error(e);
-      setOnGoingCourses(() => []);
-      setAchievedCourses(() => []);
+      setOnGoingCourses([]);
+      setAchievedCourses([]);
     }
   };
 
@@ -82,7 +82,7 @@ const CourseList = ({ setIsCourse, navigation, loggedUserId }: CourseListProps) 
     } catch (e) {
       if (e.status === 401) signOut();
       console.error(e);
-      setElearningDraftSubPrograms(() => []);
+      setElearningDraftSubPrograms([]);
     }
   };
 
@@ -120,7 +120,7 @@ const CourseList = ({ setIsCourse, navigation, loggedUserId }: CourseListProps) 
   return (
     <ScrollView style={commonStyles.container} contentContainerStyle={styles.container}>
       <Text style={commonStyles.title} testID='header'>Mes formations</Text>
-      {nextSteps.length > 0 &&
+      {!!nextSteps.length &&
         <View style={styles.nextSteps}>
           <CoursesSection items={nextSteps} title='Mes prochains rendez-vous' countStyle={styles.nextEventsCount}
             renderItem={renderNexStepsItem} type={'ÉVÉNEMENT'} />
@@ -131,14 +131,14 @@ const CourseList = ({ setIsCourse, navigation, loggedUserId }: CourseListProps) 
         <CoursesSection items={onGoingCourses} title='Mes formations en cours' renderItem={renderCourseItem}
           countStyle={styles.onGoingCoursesCount} showCatalogButton={!onGoingCourses.length} />
       </ImageBackground>
-      {achievedCourses.length > 0 &&
+      {!!achievedCourses.length &&
         <ImageBackground imageStyle={styles.achievedBackground} style={styles.sectionContainer}
           source={require('../../../../assets/images/green_section_background.png')}>
           <CoursesSection items={achievedCourses} title='Mes formations terminées' renderItem={renderCourseItem}
             countStyle={styles.achievedCoursesCount} />
         </ImageBackground>
       }
-      {elearningDraftSubPrograms.length > 0 &&
+      {!!elearningDraftSubPrograms.length &&
         <ImageBackground imageStyle={styles.onGoingAndDraftBackground} style={styles.sectionContainer}
           source={require('../../../../assets/images/purple_section_background.png')}>
           <CoursesSection items={elearningDraftSubPrograms} title='Mes formations à tester'

--- a/src/screens/courses/CourseList/index.tsx
+++ b/src/screens/courses/CourseList/index.tsx
@@ -10,13 +10,12 @@ import NextStepCell from '../../../components/steps/NextStepCell';
 import ProgramCell from '../../../components/ProgramCell';
 import { Context as AuthContext } from '../../../context/AuthContext';
 import moment from '../../../core/helpers/moment';
-import { getLoggedUserId, getUserVendorRole } from '../../../store/main/selectors';
+import { getLoggedUserId } from '../../../store/main/selectors';
 import CoursesActions from '../../../store/courses/actions';
 import commonStyles from '../../../styles/common';
 import styles from './styles';
 import { NavigationType } from '../../../types/NavigationType';
 import SubPrograms from '../../../api/subPrograms';
-import { TRAINING_ORGANISATION_MANAGER, VENDOR_ADMIN } from '../../../core/data/constants';
 import { ActionWithoutPayloadType } from '../../../types/store/StoreType';
 import CoursesSection from '../../../components/CoursesSection';
 
@@ -24,7 +23,6 @@ interface CourseListProps {
   setIsCourse: (value: boolean) => void,
   navigation: NavigationType,
   loggedUserId: string | null,
-  userVendorRole: string,
 }
 
 const formatCourseStep = (course) => {
@@ -58,7 +56,7 @@ const formatNextSteps = courses => courses.map(formatCourseStep).flat()
   .filter(step => step.slots.length)
   .sort((a, b) => moment(a.firstSlot).diff(b.firstSlot, 'days'));
 
-const CourseList = ({ setIsCourse, navigation, loggedUserId, userVendorRole }: CourseListProps) => {
+const CourseList = ({ setIsCourse, navigation, loggedUserId }: CourseListProps) => {
   const [onGoingCourses, setOnGoingCourses] = useState(new Array(0));
   const [achievedCourses, setAchievedCourses] = useState(new Array(0));
   const [elearningDraftSubPrograms, setElearningDraftSubPrograms] = useState(new Array(0));
@@ -78,15 +76,13 @@ const CourseList = ({ setIsCourse, navigation, loggedUserId, userVendorRole }: C
   };
 
   const getElearningDraftSubPrograms = async () => {
-    if ([VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER].includes(userVendorRole)) {
-      try {
-        const fetchedSubPrograms = await SubPrograms.getELearningDraftSubPrograms();
-        setElearningDraftSubPrograms(fetchedSubPrograms);
-      } catch (e) {
-        if (e.status === 401) signOut();
-        console.error(e);
-        setElearningDraftSubPrograms(() => []);
-      }
+    try {
+      const fetchedSubPrograms = await SubPrograms.getELearningDraftSubPrograms();
+      setElearningDraftSubPrograms(fetchedSubPrograms);
+    } catch (e) {
+      if (e.status === 401) signOut();
+      console.error(e);
+      setElearningDraftSubPrograms(() => []);
     }
   };
 
@@ -142,7 +138,7 @@ const CourseList = ({ setIsCourse, navigation, loggedUserId, userVendorRole }: C
             countStyle={styles.achievedCoursesCount} />
         </ImageBackground>
       }
-      {[VENDOR_ADMIN, TRAINING_ORGANISATION_MANAGER].includes(userVendorRole) &&
+      {elearningDraftSubPrograms.length > 0 &&
         <ImageBackground imageStyle={styles.onGoingAndDraftBackground} style={styles.sectionContainer}
           source={require('../../../../assets/images/purple_section_background.png')}>
           <CoursesSection items={elearningDraftSubPrograms} title='Mes formations à tester'
@@ -157,7 +153,7 @@ const CourseList = ({ setIsCourse, navigation, loggedUserId, userVendorRole }: C
   );
 };
 
-const mapStateToProps = state => ({ loggedUserId: getLoggedUserId(state), userVendorRole: getUserVendorRole(state) });
+const mapStateToProps = state => ({ loggedUserId: getLoggedUserId(state) });
 
 const mapDispatchToProps = (dispatch: ({ type }: ActionWithoutPayloadType) => void) => ({
   setIsCourse: (isCourse: boolean) => dispatch(CoursesActions.setIsCourse(isCourse)),


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que
  - Non parce que l'appel au back renvoie une 403, c'est pas forcément un problème mais je sais pas si on peut dire que c'est full compatible pour autant

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- ~~[ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas~~
- ~~[ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.~~
- [x] Je n'ai pas changé de constante

-~~ J'ai ajouté une variable d'environnement :~~
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi

- Cas d'usage : en tant que testeur j'ai accès dans mes formations aux programmes pour lesquels je suis défini comme testeur. 
Tester le cas où je me connecte en ROF/admin-vendeur (j'ai accès à tous les formations à tester), où je suis testeur (= non ROF/admin-vendeur) pour un ou plusieurs programmes (à configurer dans la webapp), où je suis testeur pour aucun programmes

PR 1 : je peux visualiser ces programmes dans la catégorie Formations à tester, onglet formation mais je ne peux pas encore y accéder en cliquant dessus (la route pour récupérer un sous programmes e-learning n'est encore accessibles qu'aux ROF/admin-vendeur uniquement, cela sera corrigé dans une seconde PR
