### PR TITLE
COM-2198: replace let with useRef

### DIFF
--- a/src/components/ZoomImage/index.tsx
+++ b/src/components/ZoomImage/index.tsx
@@ -13,7 +13,7 @@ interface ZoomImageProps {
 }
 
 const ZoomImage = ({ image, setZoomImage }: ZoomImageProps) => {
-  let lastScale = 1;
+  const lastScale = useRef<number>(1);
   const baseScale = new Animated.Value(1);
   const pinchScale = new Animated.Value(1);
   const scale = Animated.multiply(baseScale, pinchScale);
@@ -29,8 +29,8 @@ const ZoomImage = ({ image, setZoomImage }: ZoomImageProps) => {
 
   const onPinchStateChange = (event) => {
     if (event.nativeEvent.oldState === State.ACTIVE) {
-      lastScale *= event.nativeEvent.scale;
-      baseScale.setValue(lastScale);
+      lastScale.current *= event.nativeEvent.scale;
+      baseScale.setValue(lastScale.current);
       pinchScale.setValue(1);
     }
   };

--- a/src/components/activities/ActivityCell/index.tsx
+++ b/src/components/activities/ActivityCell/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useReducer, useEffect } from 'react';
 import { Text, View, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
@@ -20,6 +20,20 @@ interface ActivityCellProps {
   setQuestionnaireAnswersList: (qalist: Array<QuestionnaireAnswerType>) => void,
 }
 
+const SET_TO_GREEN = 'SET_TO_GREEN';
+const SET_TO_ORANGE = 'SET_TO_ORANGE';
+
+const colorsReducer = (state, action) => {
+  switch (action) {
+    case SET_TO_GREEN:
+      return { border: GREEN[600], background: GREEN[300], check: GREEN[500] };
+    case SET_TO_ORANGE:
+      return { border: ORANGE[600], background: ORANGE[300], check: ORANGE[500] };
+    default:
+      return state;
+  }
+};
+
 const ActivityCell = ({ activity, profileId, isCourse, setQuestionnaireAnswersList }: ActivityCellProps) => {
   const disabled = !activity.cards.length;
   const isCompleted = !!activity.activityHistories?.length;
@@ -28,13 +42,14 @@ const ActivityCell = ({ activity, profileId, isCourse, setQuestionnaireAnswersLi
   const isQuiz = activity.type === QUIZ;
   const isAboveAverage = isQuiz ? lastScore * 2 > quizCount : true;
   const navigation = useNavigation();
+  const [colors, dispatch] = useReducer(colorsReducer, { border: YELLOW[600], background: YELLOW[300] });
 
-  type colorsType = { border: string, background: string, check?: string }
-  const colors = useRef<colorsType>({ border: YELLOW[600], background: YELLOW[300] });
-  if (isCompleted && isAboveAverage) colors.current = { border: GREEN[600], background: GREEN[300], check: GREEN[500] };
-  else if (isCompleted) colors.current = { border: ORANGE[600], background: ORANGE[300], check: ORANGE[500] };
+  useEffect(() => {
+    if (isCompleted && isAboveAverage) dispatch(SET_TO_GREEN);
+    else if (isCompleted) dispatch(SET_TO_ORANGE);
+  }, [isAboveAverage, isCompleted]);
 
-  const coloredStyle = styles(colors.current.check);
+  const coloredStyle = styles(colors.check);
 
   const getQuestionnaireAnswersList = () => {
     const activityHistory = activity.activityHistories[activity.activityHistories.length - 1];
@@ -53,8 +68,8 @@ const ActivityCell = ({ activity, profileId, isCourse, setQuestionnaireAnswersLi
     <View style={coloredStyle.container}>
       <TouchableOpacity onPress={onPress} disabled={disabled}>
         <View style={coloredStyle.iconContainer}>
-          <ActivityIcon activity={activity} disabled={disabled} backgroundColor={colors.current.background}
-            borderColor={colors.current.border} />
+          <ActivityIcon activity={activity} disabled={disabled} backgroundColor={colors.background}
+            borderColor={colors.border} />
           {isCompleted && !isQuiz &&
             <Ionicons name='ios-checkmark-circle' size={ICON.MD} color={GREEN[500]} style={coloredStyle.icon}
               backgroundColor={WHITE} />}

--- a/src/components/activities/ActivityCell/index.tsx
+++ b/src/components/activities/ActivityCell/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Text, View, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
@@ -30,11 +30,11 @@ const ActivityCell = ({ activity, profileId, isCourse, setQuestionnaireAnswersLi
   const navigation = useNavigation();
 
   type colorsType = { border: string, background: string, check?: string }
-  let colors: colorsType = { border: YELLOW[600], background: YELLOW[300] };
-  if (isCompleted && isAboveAverage) colors = { border: GREEN[600], background: GREEN[300], check: GREEN[500] };
-  else if (isCompleted) colors = { border: ORANGE[600], background: ORANGE[300], check: ORANGE[500] };
+  const colors = useRef<colorsType>({ border: YELLOW[600], background: YELLOW[300] });
+  if (isCompleted && isAboveAverage) colors.current = { border: GREEN[600], background: GREEN[300], check: GREEN[500] };
+  else if (isCompleted) colors.current = { border: ORANGE[600], background: ORANGE[300], check: ORANGE[500] };
 
-  const coloredStyle = styles(colors.check);
+  const coloredStyle = styles(colors.current.check);
 
   const getQuestionnaireAnswersList = () => {
     const activityHistory = activity.activityHistories[activity.activityHistories.length - 1];
@@ -53,8 +53,8 @@ const ActivityCell = ({ activity, profileId, isCourse, setQuestionnaireAnswersLi
     <View style={coloredStyle.container}>
       <TouchableOpacity onPress={onPress} disabled={disabled}>
         <View style={coloredStyle.iconContainer}>
-          <ActivityIcon activity={activity} disabled={disabled} backgroundColor={colors.background}
-            borderColor={colors.border} />
+          <ActivityIcon activity={activity} disabled={disabled} backgroundColor={colors.current.background}
+            borderColor={colors.current.border} />
           {isCompleted && !isQuiz &&
             <Ionicons name='ios-checkmark-circle' size={ICON.MD} color={GREEN[500]} style={coloredStyle.icon}
               backgroundColor={WHITE} />}

--- a/src/components/cards/Video/index.tsx
+++ b/src/components/cards/Video/index.tsx
@@ -13,10 +13,8 @@ interface NiVideoProps {
 
 const NiVideo = ({ mediaSource }: NiVideoProps) => {
   const isIos = Platform.OS === 'ios';
-  const isIosVersionWithPlayButton = useRef<boolean>(false);
-  if (isIos) isIosVersionWithPlayButton.current = Platform.Version === '14.1';
-
-  const [playVisible, setPlayVisible] = useState<boolean>(isIosVersionWithPlayButton.current);
+  const isIosVersionWithPlayButton = isIos && Platform.Version === '14.1';
+  const [playVisible, setPlayVisible] = useState<boolean>(isIosVersionWithPlayButton);
   const [nativeControlsVisible, setNativeControlsVisible] = useState<boolean>(false);
   const videoRef = useRef<Video>(null);
 
@@ -25,7 +23,7 @@ const NiVideo = ({ mediaSource }: NiVideoProps) => {
   };
 
   const onPlaybackStatusUpdate = (playbackStatus) => {
-    if (isIosVersionWithPlayButton.current) {
+    if (isIosVersionWithPlayButton) {
       if (playbackStatus.isPlaying) setPlayVisible(false);
       else setPlayVisible(true);
     }
@@ -51,7 +49,7 @@ const NiVideo = ({ mediaSource }: NiVideoProps) => {
   return (
     // The View is needed to center the play button
     <View>
-      {isIosVersionWithPlayButton.current && playVisible &&
+      {isIosVersionWithPlayButton && playVisible &&
         <FeatherButton name='play-circle' size={ICON.XXL} onPress={displayFullscreen} color={GREY[100]}
           style={styles.play} />}
       <Video ref={videoRef} useNativeControls={nativeControlsVisible} resizeMode='contain' source={mediaSource}

--- a/src/components/cards/Video/index.tsx
+++ b/src/components/cards/Video/index.tsx
@@ -13,10 +13,10 @@ interface NiVideoProps {
 
 const NiVideo = ({ mediaSource }: NiVideoProps) => {
   const isIos = Platform.OS === 'ios';
-  let isIosVersionWithPlayButton = false;
-  if (isIos) isIosVersionWithPlayButton = Platform.Version === '14.1';
+  const isIosVersionWithPlayButton = useRef<boolean>(false);
+  if (isIos) isIosVersionWithPlayButton.current = Platform.Version === '14.1';
 
-  const [playVisible, setPlayVisible] = useState<boolean>(isIosVersionWithPlayButton);
+  const [playVisible, setPlayVisible] = useState<boolean>(isIosVersionWithPlayButton.current);
   const [nativeControlsVisible, setNativeControlsVisible] = useState<boolean>(false);
   const videoRef = useRef<Video>(null);
 
@@ -25,7 +25,7 @@ const NiVideo = ({ mediaSource }: NiVideoProps) => {
   };
 
   const onPlaybackStatusUpdate = (playbackStatus) => {
-    if (isIosVersionWithPlayButton) {
+    if (isIosVersionWithPlayButton.current) {
       if (playbackStatus.isPlaying) setPlayVisible(false);
       else setPlayVisible(true);
     }
@@ -51,7 +51,7 @@ const NiVideo = ({ mediaSource }: NiVideoProps) => {
   return (
     // The View is needed to center the play button
     <View>
-      {isIosVersionWithPlayButton && playVisible &&
+      {isIosVersionWithPlayButton.current && playVisible &&
         <FeatherButton name='play-circle' size={ICON.XXL} onPress={displayFullscreen} color={GREY[100]}
           style={styles.play} />}
       <Video ref={videoRef} useNativeControls={nativeControlsVisible} resizeMode='contain' source={mediaSource}


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que je ne fais que des changements mineurs qui n'impactent pas les routes
  - Non parce que

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- ~~[ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas~~
- ~~[ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.~~
- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi

- Cas d'usage : passage des let en useRef. Je n'ai finalement pas changé le let dans FlashCard car étant donné que les cartes sont conservés quand on switche de carte, avec un useRef, la valeur de rotationValue le serait aussi or on veut qu'elle soit réinitialisée à chaque fois qu'on revient sur la carte donc il faut utiliser un let plutôt qu'un useRef.
- TEST : 
  - quand je fais une activité j’ai bien les différentes couleurs sur la cellule à la fin de l’activité en fonction de mon résultat (jaune, orange, vert)
  - je peux lire une vidéo, la mettre en pause, l’avancer
  - si je change de carte et reviens sur la vidéo elle est de nouveau au début
  - je peux zoomer sur l’image, dézoomer, quitter le zoom
  - si je change de carte et que je reviens sur l’image, elle est dans sa position initiale
